### PR TITLE
Change server selection method

### DIFF
--- a/app/models/bigbluebutton_room.rb
+++ b/app/models/bigbluebutton_room.rb
@@ -105,7 +105,7 @@ class BigbluebuttonRoom < ActiveRecord::Base
   #
   # Triggers API call: <tt>getMeetingInfo</tt>.
   def fetch_meeting_info
-    require_server
+    require_server :get_meeting_info
 
     response = self.server.api.get_meeting_info(self.meetingid, self.moderator_api_password)
 
@@ -132,7 +132,7 @@ class BigbluebuttonRoom < ActiveRecord::Base
   #
   # Triggers API call: <tt>isMeetingRunning</tt>.
   def fetch_is_running?
-    require_server
+    require_server :is_meeting_running
     @running = self.server.api.is_meeting_running?(self.meetingid)
   end
 
@@ -140,7 +140,7 @@ class BigbluebuttonRoom < ActiveRecord::Base
   #
   # Triggers API call: <tt>end</tt>.
   def send_end
-    require_server
+    require_server :end
     response = self.server.api.end_meeting(self.meetingid, self.moderator_api_password)
 
     # enqueue an update in the meetings for later on
@@ -165,12 +165,12 @@ class BigbluebuttonRoom < ActiveRecord::Base
   # Triggers API call: <tt>create</tt>.
   def send_create(user=nil, user_opts={})
     # updates the server whenever a meeting will be created and guarantees it has a meetingid
-    self.server = select_server
+    require_server :create
+
     self.meetingid = unique_meetingid() if self.meetingid.blank?
     self.moderator_api_password = internal_password() if self.moderator_api_password.blank?
     self.attendee_api_password = internal_password() if self.attendee_api_password.blank?
     self.save unless self.new_record?
-    require_server
 
     response = internal_create_meeting(user, user_opts)
     unless response.nil?
@@ -192,7 +192,7 @@ class BigbluebuttonRoom < ActiveRecord::Base
   #
   # Uses the API but does not require a request to the server.
   def join_url(username, role, key=nil, options={})
-    require_server
+    require_server :join_meeting_url
 
     case role
     when :moderator
@@ -381,7 +381,12 @@ class BigbluebuttonRoom < ActiveRecord::Base
   # but not yet ended.
   # Any action that requires a server should call 'require_server' before
   # anything else.
-  def require_server
+  def require_server(api_method=nil)
+    serv = select_server(api_method)
+    unless serv.nil? then
+      self.server = serv
+      self.save unless self.new_record?
+    end
     if self.server.nil?
       msg = I18n.t('bigbluebutton_rails.rooms.errors.server.nil')
       raise BigbluebuttonRails::ServerRequired.new(msg)
@@ -391,11 +396,15 @@ class BigbluebuttonRoom < ActiveRecord::Base
   # This method can be overridden to change the way the server is selected
   # before a room is created
   # This one selects the server with less rooms in it
-  def select_server
-    BigbluebuttonServer.
-      select("bigbluebutton_servers.*, count(bigbluebutton_rooms.id) as room_count").
-      joins("LEFT JOIN bigbluebutton_rooms ON bigbluebutton_servers.id = bigbluebutton_rooms.server_id").
-      group(:server_id).order("room_count ASC").first
+  def select_server(api_method=nil)
+    if self.server.nil?
+      BigbluebuttonServer.
+        select("bigbluebutton_servers.*, count(bigbluebutton_rooms.id) as room_count").
+        joins("LEFT JOIN bigbluebutton_rooms ON bigbluebutton_servers.id = bigbluebutton_rooms.server_id").
+        group(:server_id).order("room_count ASC").first
+    else
+      nil
+    end
   end
 
   def init

--- a/app/models/bigbluebutton_room.rb
+++ b/app/models/bigbluebutton_room.rb
@@ -383,7 +383,7 @@ class BigbluebuttonRoom < ActiveRecord::Base
   # anything else.
   def require_server
     if self.server.nil?
-      msg = I18n.t('bigbluebutton_rails.rooms.errors.server.not_set')
+      msg = I18n.t('bigbluebutton_rails.rooms.errors.server.nil')
       raise BigbluebuttonRails::ServerRequired.new(msg)
     end
   end
@@ -394,7 +394,8 @@ class BigbluebuttonRoom < ActiveRecord::Base
   def select_server
     BigbluebuttonServer.
       select("bigbluebutton_servers.*, count(bigbluebutton_rooms.id) as room_count").
-      joins(:rooms).group(:server_id).order("room_count ASC").first
+      joins("LEFT JOIN bigbluebutton_rooms ON bigbluebutton_servers.id = bigbluebutton_rooms.server_id").
+      group(:server_id).order("room_count ASC").first
   end
 
   def init

--- a/spec/models/bigbluebutton_room_spec.rb
+++ b/spec/models/bigbluebutton_room_spec.rb
@@ -658,22 +658,20 @@ describe BigbluebuttonRoom do
 
       context "selects and requires a server" do
         let(:another_server) { FactoryGirl.create(:bigbluebutton_server) }
-
+        let(:room2) { FactoryGirl.create(:bigbluebutton_room, :server => nil) }
         context "and saves the result" do
           before do
-            room.should_receive(:select_server).and_return(another_server)
-            room.should_receive(:require_server)
-            room.should_receive(:internal_create_meeting)
-            room.server = mocked_server
-            room.send_create
+            room2.should_receive(:internal_create_meeting)
+            room2.send_create
           end
-          it { BigbluebuttonRoom.find(room.id).server_id.should == another_server.id }
+          # send_create will call require_server, so a server will be assigned
+          # to this room
+          it { BigbluebuttonRoom.find(room2.id).server_id.should_not be_nil }
         end
 
         context "and does not save when is a new record" do
           let(:new_room) { FactoryGirl.build(:bigbluebutton_room) }
           before do
-            new_room.should_receive(:select_server).and_return(another_server)
             new_room.should_receive(:require_server)
             new_room.should_receive(:internal_create_meeting).and_return(nil)
             new_room.should_not_receive(:save)
@@ -943,13 +941,27 @@ describe BigbluebuttonRoom do
     let(:room) { FactoryGirl.create(:bigbluebutton_room) }
     it { room.respond_to?(:require_server, true).should be(true) }
 
-    context "throws exception when the room has no server associated" do
-      before { room.server = nil }
-      it {
-        expect {
+    context "if the room has no server associated" do
+
+      context "assigns server to room if there is one" do
+        before {
+          room.server = nil
           room.send(:require_server)
-        }.to raise_error(BigbluebuttonRails::ServerRequired)
-      }
+        }
+        it { room.server.should_not be_nil }
+      end
+
+      context "raises exception if there are no servers to assign" do
+        before {
+          room.should_receive(:select_server).and_return(nil)
+          room.server = nil
+        }
+        it {
+          expect {
+            room.send(:require_server)
+          }.to raise_error(BigbluebuttonRails::ServerRequired)
+        }
+      end
     end
 
     context "does nothing if the room has a server associated" do


### PR DESCRIPTION
Previously it wouldn't select a server without any rooms. Now it does.
Also, the translation key in require_server was wrong. Fixed it.

This makes the behavior of select_server easily replaceable.
I thought about calling it inside require_server, but that would create an attachment between
these two functions, thus complicating possible overrides of select_server.