### PR TITLE
Feature 1571

### DIFF
--- a/app/models/bigbluebutton_room.rb
+++ b/app/models/bigbluebutton_room.rb
@@ -4,7 +4,6 @@ class BigbluebuttonRoom < ActiveRecord::Base
   belongs_to :owner, polymorphic: true
 
   belongs_to :server, class_name: 'BigbluebuttonServer'
-  delegate :available_layouts, to: :server
 
   has_many :recordings,
            :class_name => 'BigbluebuttonRecording',
@@ -367,6 +366,14 @@ class BigbluebuttonRoom < ActiveRecord::Base
     else
       nil
     end
+  end
+
+  def available_layouts
+    # Translate the keys that come from server.available_layouts.
+    # If it's not a valid key (e.g. it's already a name) keep it as it is.
+    server.available_layouts.map { |layout|
+      I18n.t(layout, default: layout)
+    }
   end
 
   protected

--- a/app/models/bigbluebutton_room.rb
+++ b/app/models/bigbluebutton_room.rb
@@ -26,6 +26,9 @@ class BigbluebuttonRoom < ActiveRecord::Base
   delegate :presenter_share_only, :presenter_share_only=, :to => :room_options
   delegate :auto_start_video, :auto_start_video=, :to => :room_options
   delegate :auto_start_audio, :auto_start_audio=, :to => :room_options
+  delegate :available_layouts, to: :server
+  delegate :available_layouts_names, to: :server
+  delegate :available_layouts_with_names, to: :server
 
   accepts_nested_attributes_for :metadata,
     :allow_destroy => true,
@@ -368,12 +371,8 @@ class BigbluebuttonRoom < ActiveRecord::Base
     end
   end
 
-  def available_layouts
-    # Translate the keys that come from server.available_layouts.
-    # If it's not a valid key (e.g. it's already a name) keep it as it is.
-    server.available_layouts.map { |layout|
-      I18n.t(layout, default: layout)
-    }
+  def available_layouts_for_select
+    available_layouts_with_names
   end
 
   protected

--- a/app/models/bigbluebutton_server.rb
+++ b/app/models/bigbluebutton_server.rb
@@ -20,7 +20,8 @@ class BigbluebuttonServer < ActiveRecord::Base
 
   delegate :update_config, to: :config
   delegate :available_layouts, to: :config
-
+  delegate :available_layouts_names, to: :config
+  delegate :available_layouts_with_names, to: :config
   validates :name,
             :presence => true,
             :uniqueness => true,

--- a/app/models/bigbluebutton_server_config.rb
+++ b/app/models/bigbluebutton_server_config.rb
@@ -21,4 +21,16 @@ class BigbluebuttonServerConfig < ActiveRecord::Base
       Rails.logger.error "Could not fetch configurations for the server #{self.server.id}. The URL probably incorrect."
     end
   end
+
+  def available_layouts_names
+    # Translate the keys that come from server.available_layouts.
+    # If it's not a valid key (e.g. it's already a name) keep it as it is.
+    available_layouts.map { |layout|
+      I18n.t(layout, default: layout)
+    }
+  end
+
+  def available_layouts_with_names
+    available_layouts_names.zip(available_layouts)
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,6 +61,15 @@ en:
       bigbluebutton_room: "Web Conference Room"
       bigbluebutton_server: "Web Conference Server"
       bigbluebutton_server_config: "Web Conference Server Configurations"
+  bbb:
+    layout:
+      name:
+        defaultlayout: "Default Layout"
+        videochat: "Video Chat"
+        webcamsfocus: "Meeting"
+        presentfocus: "Webinar"
+        lectureassistant: "Lecture assistant"
+        lecture: "Lecture"
   bigbluebutton_rails:
     bigbluebutton: BigBlueButton
     metadata:

--- a/config/locales/pt-br.yml
+++ b/config/locales/pt-br.yml
@@ -61,6 +61,15 @@ pt-br:
       bigbluebutton_room: "Sala de Webconferência"
       bigbluebutton_server: "Servidor de Webconferência"
       bigbluebutton_server_config: "Configurações do Servidor de Webconferência"
+  bbb:
+    layout:
+      name:
+        defaultlayout: "Layout Padrão"
+        videochat: "Videoconferência"
+        webcamsfocus: "Reunião"
+        presentfocus: "Webinar"
+        lectureassistant: "Assistente de aula" # ?
+        lecture: "Aula"
   bigbluebutton_rails:
     bigbluebutton: BigBlueButton
     metadata:

--- a/spec/models/bigbluebutton_room_spec.rb
+++ b/spec/models/bigbluebutton_room_spec.rb
@@ -11,8 +11,6 @@ describe BigbluebuttonRoom do
   it { should belong_to(:server) }
   it { should_not validate_presence_of(:server_id) }
 
-  it { should delegate(:available_layouts).to(:server) }
-
   it { should belong_to(:owner) }
   it { should_not validate_presence_of(:owner_id) }
   it { should_not validate_presence_of(:owner_type) }
@@ -1172,6 +1170,21 @@ describe BigbluebuttonRoom do
       it("the job should be the right one") { subject['class'].should eq('BigbluebuttonMeetingUpdater') }
       it("the job should have the correct parameters") { subject['args'].should eq([room.id]) }
     end
+  end
+
+  describe "#available_layouts" do
+    let(:room) { FactoryGirl.create(:bigbluebutton_room) }
+    let(:layout1) { "bbb.layout.name.defaultlayout" }
+    let(:layout2) { "LayoutWithoutTranslation" }
+    before {
+      mock_server_and_api
+      room.server = mocked_server
+    }
+    before {
+      BigbluebuttonServerConfig.any_instance.should_receive(:available_layouts).
+        and_return([layout1, layout2])
+    }
+    it { room.available_layouts.should == [I18n.t(layout1), layout2] }
   end
 
 end


### PR DESCRIPTION
Now the layouts are interpreted as translation keys and translated before
being shown to the user. If no translation is found, the layout's name is not changed at all.
Maybe the translations I added to the string db aren't adequate and need checking.