### PR TITLE
Call send_end when creating a meeting

### DIFF
--- a/app/models/bigbluebutton_room.rb
+++ b/app/models/bigbluebutton_room.rb
@@ -254,6 +254,7 @@ class BigbluebuttonRoom < ActiveRecord::Base
   def create_meeting(user=nil, request=nil, user_opts={})
     fetch_is_running?
     unless is_running?
+      send_end
       add_domain_to_logout_url(request.protocol, request.host_with_port) unless request.nil?
       send_create(user, user_opts)
       true

--- a/spec/models/bigbluebutton_room_spec.rb
+++ b/spec/models/bigbluebutton_room_spec.rb
@@ -901,6 +901,7 @@ describe BigbluebuttonRoom do
       before {
         room.should_receive(:is_running?).and_return(false)
         room.should_receive(:send_create).with(user, {})
+        room.should_receive(:send_end)
       }
       subject { room.create_meeting(user) }
       it { should be_truthy }
@@ -914,6 +915,7 @@ describe BigbluebuttonRoom do
         room.should_receive(:add_domain_to_logout_url).with("HTTP://", "test.com:80")
         room.should_receive(:is_running?).and_return(false)
         room.should_receive(:send_create)
+        room.should_receive(:send_end)
       }
       subject { room.create_meeting(user, request) }
       it { should be_truthy }


### PR DESCRIPTION
If the meeting is not running, we call send_end in order to
free it from memory before creating it again, thus inhibiting
occurences of duplicateWarning and idNotUnique.