### PR TITLE
Bug1686 - Automatically set the version number

### DIFF
--- a/app/models/bigbluebutton_server.rb
+++ b/app/models/bigbluebutton_server.rb
@@ -179,7 +179,7 @@ class BigbluebuttonServer < ActiveRecord::Base
     @api = BigBlueButton::BigBlueButtonApi.new(self.url, self.salt,
                                                nil, false)
     unless self.update_attributes(version: @api.version)
-      raise BigBlueButton::BigBlueButtonException.new("BigBlueButton error: Invalid API version #{version}")
+      raise BigBlueButton::BigBlueButtonException.new("BigBlueButton error: Invalid API version #{@api.version}")
     end
   end
 

--- a/app/models/bigbluebutton_server.rb
+++ b/app/models/bigbluebutton_server.rb
@@ -178,6 +178,7 @@ class BigbluebuttonServer < ActiveRecord::Base
   def force_version_update
     @api = BigBlueButton::BigBlueButtonApi.new(self.url, self.salt,
                                                nil, false)
+
     unless self.update_attributes(version: @api.version)
       raise BigBlueButton::BigBlueButtonException.new("BigBlueButton error: Invalid API version #{@api.version}")
     end
@@ -189,7 +190,7 @@ class BigbluebuttonServer < ActiveRecord::Base
     # If the user changes url/salt AND the version, we also assume that he wants
     # to force the API version, except when the version field is left empty.
     if [:url, :salt].any? { |k| self.changes.key?(k) }
-      force_version_update unless self.changes.key?(:version) and self.version.present?
+      force_version_update unless self.changes.key?(:version) and self.changes[:version].present?
     end
   end
 

--- a/spec/controllers/bigbluebutton/servers_controller_json_responses_spec.rb
+++ b/spec/controllers/bigbluebutton/servers_controller_json_responses_spec.rb
@@ -63,6 +63,7 @@ describe Bigbluebutton::ServersController do
 
       context "on success" do
         before(:each) {
+          BigbluebuttonServer.any_instance.should_receive(:force_version_update).and_return(anything)
           put :update, :id => @server.to_param, :bigbluebutton_server => new_server.attributes, :format => 'json'
         }
         it { should respond_with(:success) }

--- a/spec/controllers/bigbluebutton/servers_controller_spec.rb
+++ b/spec/controllers/bigbluebutton/servers_controller_spec.rb
@@ -146,6 +146,7 @@ describe Bigbluebutton::ServersController do
 
     context "on success" do
       before :each do
+        BigbluebuttonServer.any_instance.should_receive(:force_version_update).and_return(anything)
         expect {
           put :update, :id => @server.to_param, :bigbluebutton_server => new_server.attributes
         }.not_to change{ BigbluebuttonServer.count }
@@ -202,6 +203,7 @@ describe Bigbluebutton::ServersController do
     context "with :redir_url" do
       context "on success" do
         before(:each) {
+          BigbluebuttonServer.any_instance.should_receive(:force_version_update).and_return(anything)
           put :update, :id => @server.to_param, :bigbluebutton_server => new_server.attributes, :redir_url => '/any'
         }
         it { should respond_with(:redirect) }
@@ -221,7 +223,10 @@ describe Bigbluebutton::ServersController do
     context "doesn't override @server" do
       let!(:other_server) { FactoryGirl.create(:bigbluebutton_server) }
       before { controller.instance_variable_set(:@server, other_server) }
-      before(:each) { put :update, :id => @server.to_param, :bigbluebutton_server => new_server.attributes }
+      before(:each) {
+        BigbluebuttonServer.any_instance.should_receive(:force_version_update).and_return(anything)
+        put :update, :id => @server.to_param, :bigbluebutton_server => new_server.attributes
+      }
       it { should assign_to(:server).with(other_server) }
     end
   end

--- a/spec/controllers/bigbluebutton/servers_controller_spec.rb
+++ b/spec/controllers/bigbluebutton/servers_controller_spec.rb
@@ -145,22 +145,71 @@ describe Bigbluebutton::ServersController do
     before { @server = server } # need this to trigger let(:server) and actually create the object
 
     context "on success" do
-      before :each do
-        BigbluebuttonServer.any_instance.should_receive(:force_version_update).and_return(anything)
-        expect {
-          put :update, :id => @server.to_param, :bigbluebutton_server => new_server.attributes
-        }.not_to change{ BigbluebuttonServer.count }
+      context "if the user does not force a version to be used" do
+        let(:new_server) { FactoryGirl.build(:bigbluebutton_server) }
+
+        before :each do
+          BigbluebuttonServer.any_instance.should_receive(:force_version_update).and_return(anything)
+          expect {
+            put :update, id: @server.to_param, bigbluebutton_server: new_server.attributes
+          }.not_to change{ BigbluebuttonServer.count }
+        end
+        it {
+          saved = BigbluebuttonServer.find(@server)
+          should respond_with(:redirect)
+          should redirect_to(bigbluebutton_server_path(saved))
+        }
+        it {
+          saved = BigbluebuttonServer.find(@server)
+          saved.should have_same_attributes_as(new_server)
+        }
+        it { should set_the_flash.to(I18n.t('bigbluebutton_rails.servers.notice.update.success')) }
       end
-      it {
-        saved = BigbluebuttonServer.find(@server)
-        should respond_with(:redirect)
-        should redirect_to(bigbluebutton_server_path(saved))
-      }
-      it {
-        saved = BigbluebuttonServer.find(@server)
-        saved.should have_same_attributes_as(new_server)
-      }
-      it { should set_the_flash.to(I18n.t('bigbluebutton_rails.servers.notice.update.success')) }
+
+      context "if the version field is blank in the update" do
+        let(:new_server) { FactoryGirl.build(:bigbluebutton_server, version: "") }
+
+        before {
+          BigBlueButton::BigBlueButtonApi.any_instance.should_receive(:get_api_version).and_return("0.9")
+          expect {
+            put :update, id: @server.to_param, bigbluebutton_server: new_server.attributes
+          }.not_to change { BigbluebuttonServer.count }
+        }
+        it {
+          saved = BigbluebuttonServer.find(@server)
+          should respond_with(:redirect)
+          should redirect_to(bigbluebutton_server_path(saved))
+        }
+        it {
+          saved = BigbluebuttonServer.find(@server)
+          saved.should_not have_same_attributes_as(new_server)
+          saved.version.should == "0.9"
+        }
+        it { should set_the_flash.to(I18n.t('bigbluebutton_rails.servers.notice.update.success')) }
+      end
+
+      context "if the user forces a new version" do
+        let(:new_server) { FactoryGirl.build(:bigbluebutton_server, version: "0.8") }
+
+        before {
+          # Since a new and different version is informed, we should not query
+          # the api for a version and use the one the user set instead.
+          BigbluebuttonServer.any_instance.should_not_receive(:force_version_update)
+          expect {
+            put :update, id: @server.to_param, bigbluebutton_server: new_server.attributes
+          }.not_to change { BigbluebuttonServer.count }
+        }
+        it {
+          saved = BigbluebuttonServer.find(@server)
+          should respond_with(:redirect)
+          should redirect_to(bigbluebutton_server_path(saved))
+        }
+        it {
+          saved = BigbluebuttonServer.find(@server)
+          saved.should have_same_attributes_as(new_server)
+        }
+        it { should set_the_flash.to(I18n.t('bigbluebutton_rails.servers.notice.update.success')) }
+      end
     end
 
     context "on failure" do

--- a/spec/models/bigbluebutton_server_spec.rb
+++ b/spec/models/bigbluebutton_server_spec.rb
@@ -20,7 +20,6 @@ describe BigbluebuttonServer do
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:url) }
   it { should validate_presence_of(:salt) }
-  it { should validate_presence_of(:version) }
   it { should validate_presence_of(:param) }
 
   context "uniqueness of" do
@@ -71,7 +70,8 @@ describe BigbluebuttonServer do
   context "supported versions" do
     it { should allow_value('0.8').for(:version) }
     it { should allow_value('0.9').for(:version) }
-    it { should_not allow_value('').for(:version) }
+    # Empty value means we will fetch it from the server later.
+    it { should allow_value('').for(:version) }
     it { should_not allow_value('0.64').for(:version) }
     it { should_not allow_value('0.6').for(:version) }
     it { should_not allow_value('0.7').for(:version) }
@@ -317,11 +317,13 @@ describe BigbluebuttonServer do
 
       context "if #url changed" do
         before { server.should_receive(:update_config).once }
+        before { server.should_receive(:force_version_update).once }
         it { server.update_attributes(url: server.url + "-2") }
       end
 
       context "if #salt changed" do
         before { server.should_receive(:update_config).once }
+        before { server.should_receive(:force_version_update).once }
         it { server.update_attributes(salt: server.salt + "-2") }
       end
 


### PR DESCRIPTION
Part of this has been made in https://github.com/mconf/bigbluebutton-api-ruby/pull/11.

If we request the API and the version is not yet set in the BigbluebuttonServer model,
we record it. This avoids the constant fetching of info from the server. There are also
cases where we should force this information to be fetched, such as some updates/creates,
depending on the parameters given.