### PR TITLE
Fix destroy meeting

### DIFF
--- a/app/models/bigbluebutton_meeting.rb
+++ b/app/models/bigbluebutton_meeting.rb
@@ -7,7 +7,7 @@ class BigbluebuttonMeeting < ActiveRecord::Base
   has_one :recording,
           :class_name => 'BigbluebuttonRecording',
           :foreign_key => 'meeting_id',
-          :dependent => :nullify
+          :dependent => :destroy
 
   has_many :attendees,
            :class_name => 'BigbluebuttonAttendee',

--- a/spec/models/bigbluebutton_meeting_spec.rb
+++ b/spec/models/bigbluebutton_meeting_spec.rb
@@ -11,7 +11,7 @@ describe BigbluebuttonMeeting do
   it { should belong_to(:room) }
   it { should validate_presence_of(:room) }
 
-  it { should have_one(:recording).dependent(:nullify) }
+  it { should have_one(:recording).dependent(:destroy) }
 
   it { should validate_presence_of(:meetingid) }
   it { should ensure_length_of(:meetingid).is_at_least(1).is_at_most(100) }


### PR DESCRIPTION
New feature:
* when the user deletes a meeting, its recording will be deleted too.
