### PR TITLE
ELOSP-140 Speed up update of recordings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'mysql2'
 gem "jquery-rails"
 gem "forgery"
 gem 'rabl'
+gem 'activerecord-import'
 
 group :development do
   gem "rdoc"

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :test do
   gem "capybara-webkit" # best option found for js
   gem "launchy"
   gem "webmock"
+  gem "timecop"
 
   # to use redis in-memory and clean it in-between tests, used for resque
   gem "fakeredis", :require => "fakeredis/rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,6 +254,7 @@ GEM
     thread_safe (0.3.4)
     thread_safe (0.3.4-java)
     tilt (1.4.1)
+    timecop (0.9.1)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -306,5 +307,6 @@ DEPENDENCIES
   shoulda-matchers (~> 2.6.1)
   simplecov (>= 0.4.0)
   therubyracer (~> 0.12.0)
+  timecop
   uglifier (>= 1.0.3)
   webmock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     bigbluebutton_rails (2.2.0)
+      activerecord-import (~> 1.0)
       bigbluebutton-api-ruby (~> 1.6)
       browser (~> 0.8.0)
       rails (>= 4.0.0)
@@ -31,6 +32,8 @@ GEM
       activemodel (= 4.1.4)
       activesupport (= 4.1.4)
       arel (~> 5.0.0)
+    activerecord-import (1.0.2)
+      activerecord (>= 3.2)
     activesupport (4.1.4)
       i18n (~> 0.6, >= 0.6.9)
       json (~> 1.7, >= 1.7.7)
@@ -40,7 +43,7 @@ GEM
     addressable (2.3.6)
     arel (5.0.1.20140414130214)
     awesome_print (1.2.0)
-    bigbluebutton-api-ruby (1.6.0)
+    bigbluebutton-api-ruby (1.7.0)
       xml-simple (~> 1.1)
     browser (0.8.0)
     builder (3.2.2)
@@ -144,7 +147,7 @@ GEM
     rabl (0.10.1)
       activesupport (>= 2.3.14)
     rack (1.5.2)
-    rack-protection (1.5.3)
+    rack-protection (1.5.5)
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -177,8 +180,8 @@ GEM
     rdoc (4.1.1)
       json (~> 1.4)
     redis (3.1.0)
-    redis-namespace (1.5.3)
-      redis (~> 3.0, >= 3.0.4)
+    redis-namespace (1.6.0)
+      redis (>= 3.0.4)
     ref (1.0.5)
     require_all (1.3.2)
     resque (1.25.2)
@@ -278,6 +281,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-import
   bigbluebutton_rails!
   capybara (~> 2.2.0)
   capybara-mechanize

--- a/bigbluebutton_rails.gemspec
+++ b/bigbluebutton_rails.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.add_dependency("resque", "~> 1.25.1")
   s.add_dependency("resque-scheduler", "~> 3.0")
   s.add_dependency("browser", "~> 0.8.0")
+  s.add_dependency("activerecord-import", "~> 1.0")
 end


### PR DESCRIPTION
Two changes to make the overall sync of recordings faster:

* Import metadata and playback formats in batch instead of updating one at a time (reduced the processing time and number of database queries).
* Don't update recordings if nothing changed in them. There's a method that makes a "snapshot" of the data from getRecordings and the data already in the db to decide if each recording needs to be updated or not. If it does, everything in it will be updated.