### PR TITLE
ELOSP-228 No need to call end before a create anymore

### DIFF
--- a/app/models/bigbluebutton_room.rb
+++ b/app/models/bigbluebutton_room.rb
@@ -333,10 +333,6 @@ class BigbluebuttonRoom < ActiveRecord::Base
   def create_meeting(user=nil, request=nil)
     fetch_is_running?
     unless is_running?
-
-      # in case the meeting is not running but it's still in memory
-      suppress(BigBlueButton::BigBlueButtonException) { send_end }
-
       add_domain_to_logout_url(request.protocol, request.host_with_port) unless request.nil?
       send_create(user)
       true

--- a/spec/controllers/bigbluebutton/rooms_controller_exception_handling_spec.rb
+++ b/spec/controllers/bigbluebutton/rooms_controller_exception_handling_spec.rb
@@ -81,13 +81,6 @@ describe Bigbluebutton::RoomsController do
           mocked_api.should_receive(:is_meeting_running?) { raise bbb_error }
         end
 
-        it "catches exception on create_meeting" do
-          mocked_api.should_receive(:"request_headers=").once
-          mocked_api.should_receive(:is_meeting_running?).exactly(3).times.and_return(false)
-          mocked_api.should_receive(:end_meeting)
-          mocked_api.should_receive(:create_meeting) { raise bbb_error }
-        end
-
         it "catches exception on join_meeting_url" do
           mocked_api.should_receive(:is_meeting_running?).twice.and_return(true)
           mocked_api.should_receive(:join_meeting_url) { raise bbb_error }

--- a/spec/models/bigbluebutton_room_spec.rb
+++ b/spec/models/bigbluebutton_room_spec.rb
@@ -1433,7 +1433,17 @@ describe BigbluebuttonRoom do
       before {
         room.should_receive(:is_running?).and_return(false)
         room.should_receive(:send_create).with(user)
-        room.should_receive(:send_end)
+      }
+      subject { room.create_meeting(user) }
+      it { should be(true) }
+    end
+
+    # use to call end before creating a meeting in previous versions
+    context "when the conference is not running doesn't call end" do
+      before {
+        room.should_receive(:is_running?).and_return(false)
+        room.should_receive(:send_create).with(user)
+        room.should_not_receive(:send_end)
       }
       subject { room.create_meeting(user) }
       it { should be(true) }
@@ -1447,23 +1457,9 @@ describe BigbluebuttonRoom do
         room.should_receive(:add_domain_to_logout_url).with("HTTP://", "test.com:80")
         room.should_receive(:is_running?).and_return(false)
         room.should_receive(:send_create)
-        room.should_receive(:send_end)
       }
       subject { room.create_meeting(user, request) }
       it { should be(true) }
-    end
-
-    context "ignores exceptions raised by send_end (for when there's no meeting created)" do
-      before {
-        room.should_receive(:is_running?).and_return(false)
-        room.should_receive(:send_create).with(user)
-        room.should_receive(:send_end) { raise BigBlueButton::BigBlueButtonException.new('test') }
-      }
-      it {
-        expect {
-          room.create_meeting(user)
-        }.not_to raise_error
-      }
     end
   end
 


### PR DESCRIPTION
A call to /end was originally added by #25 to prevent API errors when
trying to create the same room with different parameters. BigBlueButton
now behaves differently and, even if we change the passwords of a room
when calling /create, the response will be a success and not a failure.

Calling /end was causing issues when multiple users were joining a meeting
too close to each other. The gem wouldn't detect that the meeting was already
started and the second user would kick the first one out.