### PR TITLE
ELOSP-297 Fix sync of unavailable recordings

### DIFF
--- a/app/models/bigbluebutton_recording.rb
+++ b/app/models/bigbluebutton_recording.rb
@@ -91,8 +91,13 @@ class BigbluebuttonRecording < ActiveRecord::Base
   def self.recording_changed?(recording, data)
     begin
       # the attributes that are considered in the comparison
-      keys = [:end_time, :meetingid,  :metadata, :playback, :published, :recordid, :size, :start_time] # rawSize is not stored at the moment
-      keys_formats = [:length, :type, :url] # :size, :processingTime are not stored at the moment
+      keys = [ # rawSize is not stored at the moment
+        :end_time, :meetingid,  :metadata, :playback, :published,
+        :recordid, :size, :start_time
+      ]
+      keys_formats = [ # :size, :processingTime are not stored at the moment
+        :length, :type, :url
+      ]
 
       # the data from getRecordings
       data_clone = data.deep_dup
@@ -176,6 +181,10 @@ class BigbluebuttonRecording < ActiveRecord::Base
           where(available: true, server: server).
           where.not(recordid: recordIDs).
           update_all(available: false)
+        BigbluebuttonRecording.
+          where(available: false, server: server).
+          where(recordid: recordIDs).
+          update_all(available: true)
       end
     end
   end

--- a/spec/models/bigbluebutton_recording_spec.rb
+++ b/spec/models/bigbluebutton_recording_spec.rb
@@ -490,6 +490,21 @@ describe BigbluebuttonRecording do
       end
     end
 
+    context "sets recording that are in the parameters as available in a full sync" do
+      before {
+        BigbluebuttonRecording.delete_all
+        @r = FactoryGirl.create(:bigbluebutton_recording, :available => false, :server => new_server, :recordid => data[0][:recordID])
+        # so it creates the recording the first time
+        BigbluebuttonRecording.sync(new_server, data, true)
+
+        BigbluebuttonRecording.find_by(recordid: data[0][:recordID])
+          .update_attributes(available: false)
+
+        BigbluebuttonRecording.sync(new_server, data, true)
+      }
+      it { @r.reload.available.should be(true) }
+    end
+
     context "doesn't set recordings that are not in the parameters as unavailable if not in a full sync" do
       before {
         BigbluebuttonRecording.delete_all


### PR DESCRIPTION
If the recording was marked as unavailable and didn't change, it would never become available again.