### PR TITLE
Don't redirect to external URLs when params[:redir_url] is set

### DIFF
--- a/lib/bigbluebutton_rails/internal_controller_methods.rb
+++ b/lib/bigbluebutton_rails/internal_controller_methods.rb
@@ -10,7 +10,8 @@ module BigbluebuttonRails
         # in the params. It's useful to have this option so that the application can
         # define to where some methods should redirect after finishing.
         def redirect_to_using_params(options={}, response_status={})
-          unless params[:redir_url].blank?
+          is_relative = !!(params[:redir_url] =~ /^\/[^\/\\]/)
+          if !params[:redir_url].blank? && is_relative
             redirect_to params[:redir_url], response_status
           else
             redirect_to options, response_status
@@ -20,16 +21,18 @@ module BigbluebuttonRails
         # Will redirect to a url defined in `params`, if any. Otherwise, renders the
         # view `action`.
         def redirect_to_params_or_render(action=nil, response_status={})
-          unless params[:redir_url].blank?
+          is_relative = params[:redir_url] =~ /^\/[^\/\\]/
+          if !params[:redir_url].blank? && is_relative
             redirect_to params[:redir_url], response_status
           else
-            render action, response_status
+            render(action, response_status)
           end
         end
 
         # Redirects to `:back` if the referer is set, otherwise redirects to `options`.
         def redirect_to_back(options={}, response_status={})
-          if !request.env["HTTP_REFERER"].blank? and request.env["HTTP_REFERER"] != request.env["REQUEST_URI"]
+          if !request.env["HTTP_REFERER"].blank? &&
+             request.env["HTTP_REFERER"] != request.env["REQUEST_URI"]
             redirect_to :back, response_status
           else
             redirect_to options, response_status

--- a/spec/lib/bigbluebutton_rails/internal_controller_methods_spec.rb
+++ b/spec/lib/bigbluebutton_rails/internal_controller_methods_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+describe BigbluebuttonRails::InternalControllerMethods, type: :controller do
+  describe "#redirect_to_using_params" do
+    let(:options) { { custom_options: 'option' } }
+    let(:response_status) { 123 }
+
+    controller do
+      include BigbluebuttonRails::InternalControllerMethods
+      def index
+        options = { custom_options: 'option' }
+        response_status = 123
+        @result = redirect_to_using_params(options, response_status).freeze
+        render :nothing => true
+      end
+    end
+
+    it "redirects to the options passed if params[:redir_url] not set" do
+      controller.should_receive(:redirect_to).with(options, response_status)
+      get :index
+    end
+
+    it "redirects to params[:redir_url] if set" do
+      redir_url = '/testing/redir'
+      controller.should_receive(:redirect_to).with(redir_url, response_status)
+      get :index, redir_url: redir_url
+    end
+
+    it "doesn't redirect to params[:redir_url] if it's an external URL" do
+      redir_url = 'https://google.com'
+      controller.should_receive(:redirect_to).with(options, response_status)
+      get :index, redir_url: redir_url
+    end
+  end
+
+  describe "#redirect_to_params_or_render" do
+    let(:action) { :test }
+    let(:response_status) { 123 }
+
+    controller do
+      include BigbluebuttonRails::InternalControllerMethods
+      def index
+        action = :test
+        response_status = 123
+        redirect_to_params_or_render(action, response_status)
+        render :nothing => true
+      end
+    end
+
+    it "renders the action if params[:redir_url] not set" do
+      controller.should_not_receive(:redirect_to)
+      controller.should_receive(:render).with(action, response_status)
+      controller.should_receive(:render).with({ nothing: true })
+      # there's an empty call to 'render' at the end for some reason
+      controller.should_receive(:render).with(no_args)
+      get :index
+    end
+
+    it "redirects to params[:redir_url] if set" do
+      redir_url = '/testing/redir'
+      controller.should_receive(:redirect_to).with(redir_url, response_status)
+      get :index, redir_url: redir_url
+    end
+
+    it "doesn't redirect to params[:redir_url] if it's an external URL" do
+      redir_url = 'https://google.com'
+      controller.should_not_receive(:redirect_to)
+      controller.should_receive(:render).with(action, response_status)
+      controller.should_receive(:render).with({ nothing: true })
+      # there's an empty call to 'render' at the end for some reason
+      controller.should_receive(:render).with(no_args)
+      get :index, redir_url: redir_url
+    end
+  end
+end


### PR DESCRIPTION
Redirect only to internal routes to prevent possible redirect abuses. Should never allow other sites to mount URLs with our domain but redirect to other domains.