### PR TITLE
ELOSP-349 User's email metadata

### DIFF
--- a/app/controllers/bigbluebutton/rooms_controller.rb
+++ b/app/controllers/bigbluebutton/rooms_controller.rb
@@ -100,7 +100,7 @@ class Bigbluebutton::RoomsController < ApplicationController
   # Used to join users into a meeting. Most of the work is done in before filters.
   # Can be called via GET or POST and accepts parameters both in the POST data and URL.
   def join
-    join_internal(@user_name, @user_role, @user_id)
+    join_internal(@user_name, @user_role, @user_id, @user_email)
   end
 
   # Used to join private rooms or to invite anonymous users (not logged)
@@ -243,12 +243,13 @@ class Bigbluebutton::RoomsController < ApplicationController
   end
 
   # Checks the parameters received when calling `join` and sets them in variables to
-  # be accessed by other methods. Sets the user's name, id and role. Gives priority to
+  # be accessed by other methods. Sets the user's name, email, id and role. Gives priority to
   # a logged user over the information provided in the params.
   def join_user_params
     # gets the user information, given priority to a possible logged user
     if bigbluebutton_user.nil?
       @user_name = params[:user].blank? ? nil : params[:user][:name]
+      @user_email = params[:user].blank? ? nil : params[:user][:email]
       @user_id = nil
     else
       @user_name = bigbluebutton_user.name
@@ -315,7 +316,7 @@ class Bigbluebutton::RoomsController < ApplicationController
   end
 
   # The internal process to join a meeting.
-  def join_internal(username, role, id)
+  def join_internal(username, role, id, email)
     begin
       # first check if we have to create the room and if the user can do it
       unless @room.fetch_is_running?
@@ -331,7 +332,7 @@ class Bigbluebutton::RoomsController < ApplicationController
       end
 
       # room created and running, try to join it
-      url = @room.parameterized_join_url(username, role, id, {}, bigbluebutton_user)
+      url = @room.parameterized_join_url(username, role, id, { 'userdata-email': email }, bigbluebutton_user)
 
       unless url.nil?
 

--- a/spec/controllers/bigbluebutton/rooms_controller_spec.rb
+++ b/spec/controllers/bigbluebutton/rooms_controller_spec.rb
@@ -649,7 +649,7 @@ describe Bigbluebutton::RoomsController do
               BigbluebuttonRails.should_receive(:use_mobile_client?).with('my-browser').and_return(true)
 
               # here's the real verification
-              controller.should_receive(:join_internal).with(user.name, :moderator, user.id)
+              controller.should_receive(:join_internal).with(user.name, :moderator, user.id, nil)
             }
             it { send(method, :join, :id => room.to_param, :auto_join => true) }
           end
@@ -662,7 +662,7 @@ describe Bigbluebutton::RoomsController do
               BigbluebuttonRails.should_receive(:use_mobile_client?).with('my-browser').and_return(true)
 
               # here's the real verification
-              controller.should_receive(:join_internal).with(user.name, :moderator, user.id)
+              controller.should_receive(:join_internal).with(user.name, :moderator, user.id, nil)
             }
             it { send(method, :join, :id => room.to_param, :desktop => true) }
           end
@@ -677,7 +677,7 @@ describe Bigbluebutton::RoomsController do
 
             # here's the validation
             controller.should_receive(:join_internal)
-              .with(user.name, :moderator, user.id)
+              .with(user.name, :moderator, user.id, nil)
           }
           it { send(method, :join, :id => room.to_param) }
         end

--- a/spec/rails_app/lib/tasks/db/populate.rake
+++ b/spec/rails_app/lib/tasks/db/populate.rake
@@ -29,7 +29,7 @@ namespace :db do
         :url => "http://bigbluebutton#{n1}.test.com/bigbluebutton/api",
         :secret => Forgery(:basic).password(:at_least => 30, :at_most => 40),
         :version => '0.9',
-        :param => "server-#{n1}"
+        :slug => "server-#{n1}"
       }
       puts "- Creating server #{params[:name]}"
       server = BigbluebuttonServer.create!(params)
@@ -44,7 +44,7 @@ namespace :db do
           :moderator_key => Forgery(:basic).password(:at_least => 10, :at_most => 16),
           :welcome_msg => Forgery(:lorem_ipsum).sentences(2),
           :private => false,
-          :param => "meeting-#{n1}-#{n2}",
+          :slug => "meeting-#{n1}-#{n2}",
           :external => false,
           :record_meeting => false,
           :duration => 0


### PR DESCRIPTION
The Elos portal sends a guest's email inside the iframe. With this data, we can create a metadata on the join action to better identify our guest users.
Tests were adapted to this new parameter and the populate was fixed.