### PR TITLE
ELOSP-441 Friendlier error on elos

### DIFF
--- a/app/controllers/bigbluebutton/recordings_controller.rb
+++ b/app/controllers/bigbluebutton/recordings_controller.rb
@@ -1,5 +1,6 @@
 class Bigbluebutton::RecordingsController < ApplicationController
   include BigbluebuttonRails::InternalControllerMethods
+  include BigbluebuttonRailsHelper
 
   respond_to :html
   before_filter :find_recording, :except => [:index]
@@ -50,7 +51,7 @@ class Bigbluebutton::RecordingsController < ApplicationController
       message = t('bigbluebutton_rails.recordings.notice.destroy.success')
     rescue BigBlueButton::BigBlueButtonException => e
       error = true
-      message = t('bigbluebutton_rails.recordings.notice.destroy.success_with_bbb_error', :error => e.to_s[0..200])
+      message = t('bigbluebutton_rails.recordings.notice.destroy.success_with_bbb_error')
     end
 
     respond_with do |format|
@@ -140,7 +141,7 @@ class Bigbluebutton::RecordingsController < ApplicationController
     rescue BigBlueButton::BigBlueButtonException => e
       respond_with do |format|
         format.html {
-          flash[:error] = e.to_s[0..200]
+          flash[:error] = api_error_msg(e)
           redirect_to_using_params bigbluebutton_recording_path(@recording)
         }
       end

--- a/app/controllers/bigbluebutton/rooms_controller.rb
+++ b/app/controllers/bigbluebutton/rooms_controller.rb
@@ -3,6 +3,7 @@ require 'bigbluebutton_api'
 
 class Bigbluebutton::RoomsController < ApplicationController
   include BigbluebuttonRails::InternalControllerMethods
+  include BigbluebuttonRailsHelper
 
   before_filter :find_room, :except => [:index, :create, :new, :join]
 
@@ -83,7 +84,7 @@ class Bigbluebutton::RoomsController < ApplicationController
       message = t('bigbluebutton_rails.rooms.notice.destroy.success')
     rescue BigBlueButton::BigBlueButtonException => e
       error = true
-      message = t('bigbluebutton_rails.rooms.notice.destroy.success_with_bbb_error', :error => e.to_s[0..200])
+      message = t('bigbluebutton_rails.rooms.notice.destroy.success_with_bbb_error')
     end
 
     # TODO: what if it fails?
@@ -121,8 +122,8 @@ class Bigbluebutton::RoomsController < ApplicationController
     begin
       @room.fetch_is_running?
     rescue BigBlueButton::BigBlueButtonException => e
-      flash[:error] = e.to_s[0..200]
-      render :json => { :running => "false", :error => "#{e.to_s[0..200]}" }
+      flash[:error] = api_error_msg(e)
+      render :json => { :running => "false", :error => "#{api_error_msg(e)}" }
     else
       info = @room.fetch_meeting_info
       render :json => { :running => "#{@room.is_running?}", :meeting_info => info}
@@ -142,7 +143,7 @@ class Bigbluebutton::RoomsController < ApplicationController
       end
     rescue BigBlueButton::BigBlueButtonException => e
       error = true
-      message = e.to_s[0..200]
+      message = api_error_msg(e)
     end
 
     if error
@@ -181,7 +182,7 @@ class Bigbluebutton::RoomsController < ApplicationController
       end
     rescue BigBlueButton::BigBlueButtonException => e
       error = true
-      message = e.to_s[0..200]
+      message = api_error_msg(e)
     end
 
     respond_with do |format|
@@ -280,7 +281,7 @@ class Bigbluebutton::RoomsController < ApplicationController
       end
     end
   rescue BigBlueButton::BigBlueButtonException => e
-    flash[:error] = e.to_s[0..200]
+    flash[:error] = api_error_msg(e)
     redirect_to_on_join_error
   end
 
@@ -348,7 +349,7 @@ class Bigbluebutton::RoomsController < ApplicationController
       end
 
     rescue BigBlueButton::BigBlueButtonException => e
-      flash[:error] = e.to_s[0..200]
+      flash[:error] = api_error_msg(e)
       redirect_to_on_join_error
     end
   end

--- a/app/controllers/bigbluebutton/servers_controller.rb
+++ b/app/controllers/bigbluebutton/servers_controller.rb
@@ -1,5 +1,6 @@
 class Bigbluebutton::ServersController < ApplicationController
   include BigbluebuttonRails::InternalControllerMethods
+  include BigbluebuttonRailsHelper
 
   respond_to :html
   before_filter :find_server, :except => [:index, :new, :create]
@@ -31,7 +32,7 @@ class Bigbluebutton::ServersController < ApplicationController
       end
     rescue BigBlueButton::BigBlueButtonException => e
       error = true
-      message = e.to_s[0..200]
+      message = api_error_msg(e)
     end
 
     # update_list works only for html
@@ -122,7 +123,7 @@ class Bigbluebutton::ServersController < ApplicationController
       message = t('bigbluebutton_rails.servers.notice.fetch_recordings.success')
     rescue BigBlueButton::BigBlueButtonException => e
       error = true
-      message = e.to_s[0..200]
+      message = api_error_msg(e)
     end
 
     respond_with do |format|
@@ -166,7 +167,7 @@ class Bigbluebutton::ServersController < ApplicationController
     rescue BigBlueButton::BigBlueButtonException => e
       respond_with do |format|
         format.html {
-          flash[:error] = e.to_s[0..200]
+          flash[:error] = api_error_msg(e)
           redirect_to_using_params recordings_bigbluebutton_server_path(@server)
         }
       end

--- a/app/helpers/bigbluebutton_rails_helper.rb
+++ b/app/helpers/bigbluebutton_rails_helper.rb
@@ -15,6 +15,10 @@ module BigbluebuttonRailsHelper
     msgs.html_safe
   end
 
+  def api_error_msg(exception)
+    exception.key ? I18n.t('bigbluebutton_rails.api.errors.default', :key => exception.key) : I18n.t('bigbluebutton_rails.api.errors.else')
+  end
+
   # Setup a BigbluebuttonRoom to show in the forms
   def setup_bigbluebutton_room(room)
     (room.metadata.count..10).each { room.metadata.build }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,8 @@ en:
         room_not_running:
           msg: "There's no meeting currently running in this room"
           title: "Meeting not running"
+        default: "Oops, something unexpected happened. Please try again later. (\"%{key}\")"
+        else: "Oops, something unexpected happened. Please try again later."
     bigbluebutton: BigBlueButton
     meetings:
       delete:
@@ -131,7 +133,7 @@ en:
       notice:
         destroy:
           success: "Recording destroyed!"
-          success_with_bbb_error: "The recording was successfully destroyed but it wasn't deleted from the videoconference server (\"%{error}\")"
+          success_with_bbb_error: "The recording was successfully destroyed but it wasn't deleted from the webconference server."
         publish:
           success: "Recording published!"
         unpublish:
@@ -160,7 +162,7 @@ en:
           success: "Room created!"
         destroy:
           success: "Room destroyed."
-          success_with_bbb_error: "The room was successfully destroyed but the meeting wasn't ended in the videoconference server (\"%{error}\")"
+          success_with_bbb_error: "The room was successfully destroyed but the meeting wasn't ended in the webconference server."
         end:
           not_running: "The meeting could not be ended because it is not running."
           success: "The meeting was successfully ended."

--- a/config/locales/pt-br.yml
+++ b/config/locales/pt-br.yml
@@ -70,6 +70,10 @@ pt-br:
       bigbluebutton_server: "Servidor de Videoconferência"
       bigbluebutton_server_config: "Configurações do Servidor de Videoconferência"
   bigbluebutton_rails:
+    api:
+      errors:
+        default: "Ops, parece que algo inesperado aconteceu. Tente novamente mais tarde. (\"%{key}\")"
+        else: "Ops, parece que algo inesperado aconteceu. Tente novamente mais tarde."
     bigbluebutton: BigBlueButton
     meetings:
       delete:
@@ -111,7 +115,7 @@ pt-br:
       notice:
         destroy:
           success: "Gravação destruida!"
-          success_with_bbb_error: "A gravação foi destruída com sucesso mas não foi removida do servidor de videoconferência (\"%{error}\")"
+          success_with_bbb_error: "A gravação foi destruída com sucesso mas não foi removida do servidor de webconferência."
         publish:
           success: "Gravação publicada!"
         unpublish:
@@ -140,7 +144,7 @@ pt-br:
           success: "Sala criada!"
         destroy:
           success: "Reunião destruída!"
-          success_with_bbb_error: "A sala foi destruída com sucesso mas a reunião não foi finalizada no servidor de videoconferência (\"%{error}\")"
+          success_with_bbb_error: "A sala foi destruída com sucesso mas a reunião não foi finalizada no servidor de webconferência."
         end:
           not_running: "A reunião não pôde ser finalizada pois não está em andamento."
           success: "A reunião foi finalizada com sucesso."

--- a/spec/controllers/bigbluebutton/recordings_controller_spec.rb
+++ b/spec/controllers/bigbluebutton/recordings_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+include BigbluebuttonRailsHelper
 
 describe Bigbluebutton::RecordingsController do
   render_views
@@ -170,7 +171,7 @@ describe Bigbluebutton::RecordingsController do
       it { should respond_with(:redirect) }
       it { should redirect_to bigbluebutton_recordings_url }
       it {
-        msg = I18n.t('bigbluebutton_rails.recordings.notice.destroy.success_with_bbb_error', :error => bbb_error_msg[0..200])
+        msg = I18n.t('bigbluebutton_rails.recordings.notice.destroy.success_with_bbb_error')
         should set_the_flash.to(msg)
       }
     end
@@ -403,7 +404,7 @@ describe Bigbluebutton::RecordingsController do
         before(:each) { post action, :id => recording.to_param }
         it { should respond_with(:redirect) }
         it { should redirect_to(bigbluebutton_recording_path(recording)) }
-        it { should set_the_flash.to(bbb_error_msg[0..200]) }
+        it { should set_the_flash.to(api_error_msg(bbb_error)) }
       end
 
       context "returns error if there's no server associated" do

--- a/spec/controllers/bigbluebutton/rooms_controller_exception_handling_spec.rb
+++ b/spec/controllers/bigbluebutton/rooms_controller_exception_handling_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+include BigbluebuttonRailsHelper
 
 describe Bigbluebutton::RoomsController do
   render_views
@@ -31,7 +32,7 @@ describe Bigbluebutton::RoomsController do
         should respond_with(:redirect)
         should redirect_to bigbluebutton_rooms_url
 
-        msg = I18n.t('bigbluebutton_rails.rooms.notice.destroy.success_with_bbb_error', :error => bbb_error_msg[0..200])
+        msg = I18n.t('bigbluebutton_rails.rooms.notice.destroy.success_with_bbb_error')
         should set_the_flash.to(msg)
       end
     end
@@ -42,8 +43,8 @@ describe Bigbluebutton::RoomsController do
       }
       before(:each) { get :running, :id => room.to_param }
       it { should respond_with(:success) }
-      it { response.body.should == build_running_json(false,{}, bbb_error_msg[0..200]) }
-      it { should set_the_flash.to(bbb_error_msg[0..200]) }
+      it { response.body.should == build_running_json(false,{}, api_error_msg(bbb_error)) }
+      it { should set_the_flash.to(api_error_msg(bbb_error)) }
     end
 
     describe "#end" do
@@ -60,7 +61,7 @@ describe Bigbluebutton::RoomsController do
         get :end, :id => room.to_param
         should respond_with(:redirect)
         should redirect_to(http_referer)
-        should set_the_flash.to(bbb_error_msg[0..200])
+        should set_the_flash.to(api_error_msg(bbb_error))
       end
     end
 
@@ -92,7 +93,7 @@ describe Bigbluebutton::RoomsController do
           get :join, :id => room.to_param
           should respond_with(:redirect)
           should redirect_to(http_referer)
-          should set_the_flash.to(bbb_error_msg[0..200])
+          should set_the_flash.to(api_error_msg(bbb_error))
         end
 
       end
@@ -118,7 +119,7 @@ describe Bigbluebutton::RoomsController do
           get :join, :id => room.to_param
           should respond_with(:redirect)
           should redirect_to(http_referer)
-          should set_the_flash.to(bbb_error_msg[0..200])
+          should set_the_flash.to(api_error_msg(bbb_error))
         end
       end
 

--- a/spec/controllers/bigbluebutton/rooms_controller_spec.rb
+++ b/spec/controllers/bigbluebutton/rooms_controller_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'bigbluebutton_api'
+include BigbluebuttonRailsHelper
 
 # Some tests mock the server and its API object
 # We don't want to trigger real API calls here (this is done in the integration tests)
@@ -370,7 +371,7 @@ describe Bigbluebutton::RoomsController do
       it { should respond_with(:redirect) }
       it { should redirect_to bigbluebutton_rooms_url }
       it {
-        msg = I18n.t('bigbluebutton_rails.rooms.notice.destroy.success_with_bbb_error', :error => bbb_error_msg[0..200])
+        msg = I18n.t('bigbluebutton_rails.rooms.notice.destroy.success_with_bbb_error')
         should set_the_flash.to(msg)
       }
     end
@@ -434,7 +435,7 @@ describe Bigbluebutton::RoomsController do
       before { mocked_api.should_receive(:is_meeting_running?)  { raise bbb_error } }
       before(:each) { get :running, :id => room.to_param }
       it { should respond_with(:success) }
-      it { should set_the_flash.to(bbb_error_msg[0..200]) }
+      it { should set_the_flash.to(api_error_msg(bbb_error)) }
     end
 
     context "doesn't override @room" do
@@ -732,7 +733,7 @@ describe Bigbluebutton::RoomsController do
       before { mocked_api.should_receive(:is_meeting_running?) { raise bbb_error } }
       before(:each) { get :end, :id => room.to_param }
       it { should respond_with(:redirect) }
-      it { should set_the_flash.to(bbb_error_msg[0..200]) }
+      it { should set_the_flash.to(api_error_msg(bbb_error)) }
     end
 
     context "doesn't override @room" do
@@ -825,7 +826,7 @@ describe Bigbluebutton::RoomsController do
       }
       it { should respond_with(:redirect) }
       it { should redirect_to(bigbluebutton_room_path(room)) }
-      it { should set_the_flash.to(bbb_error_msg[0..200]) }
+      it { should set_the_flash.to(api_error_msg(bbb_error)) }
     end
 
     context "if the room has no server associated" do
@@ -1197,7 +1198,7 @@ describe Bigbluebutton::RoomsController do
       before(:each) { get :join, :id => room.to_param }
       it { should respond_with(:redirect) }
       it { should redirect_to(http_referer) }
-      it { should set_the_flash.to(bbb_error_msg[0..200]) }
+      it { should set_the_flash.to(api_error_msg(bbb_error)) }
     end
 
     context "doesn't break if a guest user has permission to create a meeting" do

--- a/spec/controllers/bigbluebutton/servers_controller_spec.rb
+++ b/spec/controllers/bigbluebutton/servers_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+include BigbluebuttonRailsHelper
 
 describe Bigbluebutton::ServersController do
   render_views
@@ -309,7 +310,7 @@ describe Bigbluebutton::ServersController do
       context "at fetch_meetings" do
         before { server.should_receive(:fetch_meetings) { raise bbb_error } }
         before(:each) { get :activity, :id => server.to_param }
-        it { should set_the_flash.to(bbb_error_msg[0..200]) }
+        it { should set_the_flash.to(api_error_msg(bbb_error)) }
       end
 
       context "at fetch_meeting_info" do
@@ -319,7 +320,7 @@ describe Bigbluebutton::ServersController do
           room1.should_receive(:fetch_meeting_info) { raise bbb_error }
         end
         before(:each) { get :activity, :id => server.to_param }
-        it { should set_the_flash.to(bbb_error_msg[0..200]) }
+        it { should set_the_flash.to(api_error_msg(bbb_error)) }
       end
     end
 
@@ -361,7 +362,7 @@ describe Bigbluebutton::ServersController do
       before(:each) { post :publish_recordings, :id => server.to_param, :recordings => recording_ids }
       it { should respond_with(:redirect) }
       it { should redirect_to(recordings_bigbluebutton_server_path(server)) }
-      it { should set_the_flash.to(bbb_error_msg[0..200]) }
+      it { should set_the_flash.to(api_error_msg(bbb_error)) }
     end
 
     context "with :redir_url" do
@@ -420,7 +421,7 @@ describe Bigbluebutton::ServersController do
       }
       it { should respond_with(:redirect) }
       it { should redirect_to(recordings_bigbluebutton_server_path(server)) }
-      it { should set_the_flash.to(bbb_error_msg[0..200]) }
+      it { should set_the_flash.to(api_error_msg(bbb_error)) }
     end
 
     context "with :redir_url" do
@@ -487,7 +488,7 @@ describe Bigbluebutton::ServersController do
       }
       it { should respond_with(:redirect) }
       it { should redirect_to(bigbluebutton_server_path(server)) }
-      it { should set_the_flash.to(bbb_error_msg[0..200]) }
+      it { should set_the_flash.to(api_error_msg(bbb_error)) }
     end
 
     context "when filtering by meetingID" do


### PR DESCRIPTION
These are the same changes made to RNP, adapted to the branch Elos uses.

Created a new method on bigbluebutton_rails_helper that sends either a message with an error key or without it. This method is called whenever a controller needs a message for a Bigbluebutton Exception's flash.
Updated the specs to properly use this new method.

To run the tests I ran this command inside the test bash:
bundle exec rake rails_app:install rails_app:db spec

To link bigbluebutton-api-ruby, try adding to the Gemfile:
gem 'bigbluebutton-api-ruby', git: 'https://github.com/mconf/bigbluebutton-api-ruby.git', branch: 'feature-friendlier-errors'

If this does not work, follow the steps in https://www.notion.so/Sobre-as-gems-do-BigBlueButton-0693a8c0d065426981ff6d35a9c226b8