### PR TITLE
RNPP-157 Gem update to 3.1.0 - Fix recordings without meetings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -91,6 +91,7 @@ namespace :spec do
     sh "bundle exec rails generate bigbluebutton_rails:install 2.3.1 --migration-only --force"
     sh "bundle exec rails generate bigbluebutton_rails:install 3.0.0 --migration-only --force"
     sh "bundle exec rails generate bigbluebutton_rails:install 3.0.1 --migration-only --force"
+    sh "bundle exec rails generate bigbluebutton_rails:install 3.1.0 --migration-only --force"
 
     sh "bundle exec rake db:drop RAILS_ENV=test"
     sh "bundle exec rake db:create RAILS_ENV=test"
@@ -102,6 +103,7 @@ namespace :spec do
     # Rake::Task["cucumber"].invoke
 
     cd "spec/rails_app/"
+    sh "bundle exec rails destroy bigbluebutton_rails:install 3.1.0 --migration-only"
     sh "bundle exec rails destroy bigbluebutton_rails:install 3.0.1 --migration-only"
     sh "bundle exec rails destroy bigbluebutton_rails:install 3.0.0 --migration-only"
     sh "bundle exec rails destroy bigbluebutton_rails:install 2.3.1 --migration-only"

--- a/app/models/bigbluebutton_recording.rb
+++ b/app/models/bigbluebutton_recording.rb
@@ -265,13 +265,32 @@ class BigbluebuttonRecording < ActiveRecord::Base
   end
 
   # Syncs data that's not directly stored in the recording itself but in
-  # associated models (e.g. metadata and playback formats).
+  # associated models (e.g. metadata, meeting and playback formats).
   # The format expected for 'data' follows the format returned by
   # BigBlueButtonApi#get_recordings but with the keys already converted to our format.
   def self.sync_additional_data(recording, data)
     sync_metadata(recording, data[:metadata]) if data[:metadata]
+    update_meeting_creator(recording)
     if data[:playback] and data[:playback][:format]
       sync_playback_formats(recording, data[:playback][:format])
+    end
+  end
+
+  # Updates the creator_id and creator_name on the recording's meeting.
+  # Uses the recordings metadata.
+  def self.update_meeting_creator(recording)
+    if recording.metadata.present?
+      if recording.meeting.present?
+        attrs = {}
+        begin
+          attrs[:creator_id] = recording.metadata.find_by(name: 'bbbrails-user-id').content.to_i
+          attrs[:creator_name] = recording.metadata.find_by(name: 'bbbrails-user-name').content
+        rescue
+          attrs[:creator_id] = nil
+          attrs[:creator_name] = nil
+        end
+        recording.meeting.update_attributes(attrs)
+      end
     end
   end
 
@@ -361,6 +380,9 @@ class BigbluebuttonRecording < ActiveRecord::Base
             div_start_time = (start_time/10)
             meeting = BigbluebuttonMeeting.where("meetingid = ? AND create_time DIV 10 = ?", recording.meetingid, div_start_time).last
           end
+          if meeting.nil?
+            meeting = build_meeting(recording)
+          end
         logger.info "Recording: meeting found for the recording #{recording.inspect}: #{meeting.inspect}"
       end
     end
@@ -368,4 +390,28 @@ class BigbluebuttonRecording < ActiveRecord::Base
     meeting
   end
 
+  # Builds a meeting for a given recording. Currently it's being saved on self.create_recording
+  # by Active Record Autosave Association.
+  def self.build_meeting(recording)
+    attrs = {
+      server_id: recording.server.id,
+      room_id: recording.room_id,
+      meetingid: recording.meetingid,
+      name: recording.name,
+      running: false,
+      recorded: true,
+      creator_id: nil,
+      creator_name: nil,
+      server_url: recording.server.url,
+      server_secret: recording.server.secret,
+      create_time: recording.start_time * 1000,
+      ended: true,
+      finish_time: recording.end_time,
+      title: recording.name
+    }
+
+    meeting = BigbluebuttonMeeting.new(attrs)
+
+    meeting
+  end
 end

--- a/lib/generators/bigbluebutton_rails/templates/migration_3_1_0.rb
+++ b/lib/generators/bigbluebutton_rails/templates/migration_3_1_0.rb
@@ -1,6 +1,76 @@
 class BigbluebuttonRailsTo310 < ActiveRecord::Migration
-  def change
-    drop_table :bigbluebutton_server_configs
-    drop_table :bigbluebutton_room_options
+  class BigbluebuttonMeeting < ActiveRecord::Base
+    has_one :recording,
+            :class_name => 'BigbluebuttonRailsTo310::BigbluebuttonRecording',
+            :foreign_key => 'meeting_id',
+            :dependent => :destroy
+  end
+
+  class BigbluebuttonRecording < ActiveRecord::Base
+    has_many  :metadata,
+              :class_name => 'BigbluebuttonRailsTo310::BigbluebuttonMetadata',
+              :as => :owner,
+              :dependent => :destroy
+
+    belongs_to :meeting, class_name: 'BigbluebuttonRailsTo310::BigbluebuttonMeeting'
+    belongs_to :server, class_name: 'BigbluebuttonRailsTo310::BigbluebuttonServer'
+
+    validates :server, :presence => true
+  end
+
+  class BigbluebuttonMetadata < ActiveRecord::Base
+  end
+
+  class BigbluebuttonServer < ActiveRecord::Base
+  end
+
+  def up
+    BigbluebuttonRecording.where(meeting_id: nil).where.not(room_id: nil).find_each do |recording|
+      attrs = {
+        server_id: recording.server.id,
+        room_id: recording.room_id,
+        meetingid: recording.meetingid,
+        name: recording.name,
+        running: false,
+        recorded: true,
+        creator_id: nil,
+        creator_name: nil,
+        server_url: recording.server.url,
+        server_secret: recording.server.secret,
+        create_time: recording.start_time * 1000,
+        ended: true,
+        finish_time: recording.end_time,
+        title: recording.name
+      }
+
+      if recording.metadata.present?
+        attrs[:creator_id] = recording.metadata.find_by(name: 'bbbrails-user-id').content.to_i
+        attrs[:creator_name] = recording.metadata.find_by(name: 'bbbrails-user-name').content
+      end
+
+      meeting = BigbluebuttonMeeting.create(attrs)
+      recording.update_attributes(meeting_id: meeting.id)
+      puts "Created a meeting for the recording id-#{recording.id}: Meeting id-#{meeting.id}"
+    end
+  end
+
+  def down
+    create_table :bigbluebutton_server_configs do |t|
+      t.integer :server_id
+      t.text :available_layouts
+      t.timestamps
+    end
+
+    create_table :bigbluebutton_room_options do |t|
+      t.integer :room_id
+      t.string :default_layout
+      t.boolean :presenter_share_only
+      t.boolean :auto_start_video
+      t.boolean :auto_start_audio
+      t.string :background
+      t.timestamps
+    end
+    
+    raise ActiveRecord::IrreversibleMigration, "Can't undo due to loss of values during migration"
   end
 end

--- a/lib/generators/bigbluebutton_rails/templates/migration_3_1_0.rb
+++ b/lib/generators/bigbluebutton_rails/templates/migration_3_1_0.rb
@@ -55,22 +55,6 @@ class BigbluebuttonRailsTo310 < ActiveRecord::Migration
   end
 
   def down
-    create_table :bigbluebutton_server_configs do |t|
-      t.integer :server_id
-      t.text :available_layouts
-      t.timestamps
-    end
-
-    create_table :bigbluebutton_room_options do |t|
-      t.integer :room_id
-      t.string :default_layout
-      t.boolean :presenter_share_only
-      t.boolean :auto_start_video
-      t.boolean :auto_start_audio
-      t.string :background
-      t.timestamps
-    end
-    
     raise ActiveRecord::IrreversibleMigration, "Can't undo due to loss of values during migration"
   end
 end


### PR DESCRIPTION
* When creating a recording, if we don't find a meeting for it, a new meeting
is created and associated to that recording.
* That same procedure was applied to every recording without a meeting
on the upgrade gem migration.