### PR TITLE
GEMRAILS-2 Improve the synchronization of recordings

### DIFF
--- a/app/models/bigbluebutton_recording.rb
+++ b/app/models/bigbluebutton_recording.rb
@@ -106,7 +106,7 @@ class BigbluebuttonRecording < ActiveRecord::Base
       # the attributes that are considered in the comparison
       keys = [ # rawSize is not stored at the moment
         :end_time, :meetingid,  :metadata, :playback, :published,
-        :recordid, :size, :start_time
+        :recordid, :size, :start_time, :state, :name
       ]
       keys_formats = [ # :size, :processingTime are not stored at the moment
         :length, :type, :url

--- a/app/models/bigbluebutton_recording.rb
+++ b/app/models/bigbluebutton_recording.rb
@@ -158,21 +158,23 @@ class BigbluebuttonRecording < ActiveRecord::Base
   #
   # TODO: catch exceptions on creating/updating recordings
   def self.sync(server, recordings, full_sync=false)
+
+    logger.info "Sync recordings: starting a sync for server=#{server.url};#{server.secret} full_sync=#{full_sync}"
     recordings.each do |rec|
       rec_obj = BigbluebuttonRecording.find_by_recordid(rec[:recordID])
       rec_data = adapt_recording_hash(rec)
-      changed = !rec_obj.present? ||
-                self.recording_changed?(rec_obj, rec_data)
+      changed = !rec_obj.present? || self.recording_changed?(rec_obj, rec_data)
 
       if changed
+        logger.info "Sync recordings: detected that the recording changed #{rec[:recordID]}"
         BigbluebuttonRecording.transaction do
           if rec_obj
-            logger.info "Sync recordings: updating recording #{rec_obj.inspect}"
-            logger.debug "Sync recordings: recording data #{rec_data.inspect}"
+            logger.info "Sync recordings: updating recording #{rec[:recordID]}"
+            logger.debug "Sync recordings: updating recording with data #{rec_data.inspect}"
             self.update_recording(server, rec_obj, rec_data)
           else
-            logger.info "Sync recordings: creating recording"
-            logger.debug "Sync recordings: recording data #{rec_data.inspect}"
+            logger.info "Sync recordings: creating recording #{rec[:recordID]}"
+            logger.debug "Sync recordings: creating recording with data #{rec_data.inspect}"
             self.create_recording(server, rec_data)
           end
         end
@@ -200,6 +202,8 @@ class BigbluebuttonRecording < ActiveRecord::Base
           update_all(available: true)
       end
     end
+
+    logger.info "Sync recordings: finished a sync for server=#{server.url};#{server.secret} full_sync=#{full_sync}"
   end
 
   protected

--- a/app/models/bigbluebutton_room.rb
+++ b/app/models/bigbluebutton_room.rb
@@ -395,11 +395,9 @@ class BigbluebuttonRoom < ActiveRecord::Base
 
     if to_be_finished.count > 0
       # start trying to get the recording for this room
-      # since we don't have a way to know exactly when a recording is done, we
-      # have to keep polling the server for them
-      # 3 times so it tries at: 4, 9, 14 and 19
-      # no point trying more since there is a global synchronization process
-      Resque.enqueue_in(1.minutes, ::BigbluebuttonRecordingsForRoomWorker, self.id, 10)
+      intervals  = BigbluebuttonRails.configuration.recording_sync_for_room_intervals
+      tries = intervals.length - 1
+      Resque.enqueue_in(intervals[0], ::BigbluebuttonRecordingsForRoomWorker, self.id, tries)
     end
   end
 

--- a/app/models/bigbluebutton_room.rb
+++ b/app/models/bigbluebutton_room.rb
@@ -425,10 +425,14 @@ class BigbluebuttonRoom < ActiveRecord::Base
     end
   end
 
-  def fetch_recordings(filter={})
+  # Synchronizes all the recordings for this room. Will only get recordings with the
+  # default states (won't get recordings with the state 'deleted', for instance).
+  def fetch_recordings
     server = BigbluebuttonRails.configuration.select_server.call(self, :get_recordings)
     if server.present?
-      server.fetch_recordings(filter.merge({ meetingID: self.meetingid }))
+      states = BigbluebuttonRecording::STATES.values
+      scope = BigbluebuttonRecording.where(room: self, state: states)
+      server.fetch_recordings({ meetingID: self.meetingid, state: states }, scope)
       true
     else
       false

--- a/app/models/bigbluebutton_server.rb
+++ b/app/models/bigbluebutton_server.rb
@@ -137,14 +137,17 @@ class BigbluebuttonServer < ActiveRecord::Base
   def fetch_recordings(filter=nil, sync_scope=nil)
     filter ||= {}
     logger.info "Fetching recordings on #{self.url} with filter: #{filter.inspect}"
+
+    sync_started_at = DateTime.now
     recordings = self.api.get_recordings(filter)
+
     if recordings and recordings[:recordings]
 
       # if no scope is set and there are no filters, set the scope to all recordings
       # in this server
       sync_scope = BigbluebuttonRecording.where(server: self) if filter.blank? && sync_scope.nil?
 
-      BigbluebuttonRecording.sync(self, recordings[:recordings], sync_scope)
+      BigbluebuttonRecording.sync(self, recordings[:recordings], sync_scope, sync_started_at)
     end
   end
 

--- a/app/models/bigbluebutton_server.rb
+++ b/app/models/bigbluebutton_server.rb
@@ -134,12 +134,17 @@ class BigbluebuttonServer < ActiveRecord::Base
   #          metadata values.
   #
   # Triggers API call: <tt>getRecordings</tt>.
-  def fetch_recordings(filter=nil, full_sync=false)
+  def fetch_recordings(filter=nil, sync_scope=nil)
     filter ||= {}
-    logger.info "Fetching recordings for the server #{self.inspect} with filter: #{filter.inspect}"
+    logger.info "Fetching recordings on #{self.url} with filter: #{filter.inspect}"
     recordings = self.api.get_recordings(filter)
     if recordings and recordings[:recordings]
-      BigbluebuttonRecording.sync(self, recordings[:recordings], full_sync)
+
+      # if no scope is set and there are no filters, set the scope to all recordings
+      # in this server
+      sync_scope = BigbluebuttonRecording.where(server: self) if filter.blank? && sync_scope.nil?
+
+      BigbluebuttonRecording.sync(self, recordings[:recordings], sync_scope)
     end
   end
 

--- a/app/workers/bigbluebutton_recordings_for_room_worker.rb
+++ b/app/workers/bigbluebutton_recordings_for_room_worker.rb
@@ -21,7 +21,7 @@ class BigbluebuttonRecordingsForRoomWorker
     if room.present?
       Rails.logger.info "BigbluebuttonRecordingsForRoomWorker getting recordings for meetingid=#{room.meetingid}"
 
-      room.fetch_recordings(state: BigbluebuttonRecording::STATES.values)
+      room.fetch_recordings
 
       intervals = BigbluebuttonRails.configuration.recording_sync_for_room_intervals
       idx = intervals.length - tries_left

--- a/app/workers/bigbluebutton_recordings_for_room_worker.rb
+++ b/app/workers/bigbluebutton_recordings_for_room_worker.rb
@@ -25,6 +25,7 @@ class BigbluebuttonRecordingsForRoomWorker
 
       intervals = BigbluebuttonRails.configuration.recording_sync_for_room_intervals
       idx = intervals.length - tries_left
+      wait = intervals[idx]
       wait = intervals[intervals.length - 1] if wait.nil?
 
       Resque.enqueue_in(wait, ::BigbluebuttonRecordingsForRoomWorker, room_id, tries_left - 1)

--- a/app/workers/bigbluebutton_update_recordings_worker.rb
+++ b/app/workers/bigbluebutton_update_recordings_worker.rb
@@ -7,5 +7,6 @@ class BigbluebuttonUpdateRecordingsWorker
   def self.perform(server_id=nil)
     Rails.logger.info "BigbluebuttonUpdateRecordingsWorker worker running"
     BigbluebuttonRails::BackgroundTasks.update_recordings(server_id)
+    Rails.logger.info "BigbluebuttonUpdateRecordingsWorker worker ended"
   end
 end

--- a/app/workers/bigbluebutton_update_recordings_worker.rb
+++ b/app/workers/bigbluebutton_update_recordings_worker.rb
@@ -6,7 +6,10 @@ class BigbluebuttonUpdateRecordingsWorker
 
   def self.perform(server_id=nil)
     Rails.logger.info "BigbluebuttonUpdateRecordingsWorker worker running"
-    BigbluebuttonRails::BackgroundTasks.update_recordings(server_id)
+
+    # TODO: configurable filter of rooms
+    BigbluebuttonRails::BackgroundTasks.update_recordings_by_room
+
     Rails.logger.info "BigbluebuttonUpdateRecordingsWorker worker ended"
   end
 end

--- a/app/workers/bigbluebutton_update_recordings_worker.rb
+++ b/app/workers/bigbluebutton_update_recordings_worker.rb
@@ -7,8 +7,8 @@ class BigbluebuttonUpdateRecordingsWorker
   def self.perform(server_id=nil)
     Rails.logger.info "BigbluebuttonUpdateRecordingsWorker worker running"
 
-    # TODO: configurable filter of rooms
-    BigbluebuttonRails::BackgroundTasks.update_recordings_by_room
+    query = BigbluebuttonRails.configuration.rooms_for_full_recording_sync.call
+    BigbluebuttonRails::BackgroundTasks.update_recordings_by_room(query)
 
     Rails.logger.info "BigbluebuttonUpdateRecordingsWorker worker ended"
   end

--- a/config/resque/workers_schedule.yml
+++ b/config/resque/workers_schedule.yml
@@ -5,7 +5,6 @@ finish_meetings:
   description: "Checks for meetings that finished and mark as finished. Same as 'rake bigbluebutton_rails:meetings:finish'."
 
 update_recordings:
-  every:
-    - "30m"
+  cron: "0 0,12 * * *" # twice a day
   class: BigbluebuttonUpdateRecordingsWorker
   description: "Gets the recordings in the server to populate the db. Same as 'rake bigbluebutton_rails:recordings:update'."

--- a/lib/bigbluebutton_rails/configuration.rb
+++ b/lib/bigbluebutton_rails/configuration.rb
@@ -17,6 +17,7 @@ module BigbluebuttonRails
     attr_accessor :downloadable_playback_types
     attr_accessor :debug
     attr_accessor :api_timeout
+    attr_accessor :recording_sync_for_room_intervals
 
     # methods
     attr_accessor :select_server
@@ -102,6 +103,19 @@ module BigbluebuttonRails
       # Set it to an empty string to disable authentication. Set it to nil to deny all
       # requests (disable the API).
       @api_secret = nil
+
+      # Sequence of intervals for the worker that monitors the recordings of a room after
+      # a meeting ends in that room. Sleep this amount of time between each `getRecordings`
+      # to the room.
+      # Start faster, get slower later on. Tries for a total of about 24h.
+      @recording_sync_for_room_intervals = [
+        1.minute,
+        5.minutes, 5.minutes,
+        10.minutes, 10.minutes,
+        30.minutes, 30.minutes, 30.minutes,
+        2.hours, 2.hours,
+        3.hours, 3.hours, 3.hours, 3.hours, 3.hours, 3.hours
+      ]
     end
 
     def set_controllers(options)

--- a/lib/generators/bigbluebutton_rails/templates/migration.rb
+++ b/lib/generators/bigbluebutton_rails/templates/migration.rb
@@ -51,6 +51,7 @@ class CreateBigbluebuttonRails < ActiveRecord::Migration
       t.boolean :available, :default => true
       t.integer :size, limit: 8, default: 0
       t.text :recording_users
+      t.string :bigbluebutton_recordings, :state
       t.timestamps
     end
     add_index :bigbluebutton_recordings, :room_id

--- a/spec/controllers/bigbluebutton/rooms_controller_spec.rb
+++ b/spec/controllers/bigbluebutton/rooms_controller_spec.rb
@@ -792,13 +792,16 @@ describe Bigbluebutton::RoomsController do
     before do
       mock_server_and_api
     end
+    let(:scope) {
+      BigbluebuttonRecording.where(room: room, state: BigbluebuttonRecording::STATES.values)
+    }
     let(:filter) {
-      { :meetingID => room.meetingid }
+      { :meetingID => room.meetingid, :state => BigbluebuttonRecording::STATES.values }
     }
 
     context "on success" do
       before(:each) {
-        mocked_server.should_receive(:fetch_recordings).with(filter)
+        mocked_server.should_receive(:fetch_recordings).with(filter, scope)
         post :fetch_recordings, :id => room.to_param
       }
       it { should respond_with(:redirect) }
@@ -808,7 +811,7 @@ describe Bigbluebutton::RoomsController do
 
     context "responds to :json" do
       before(:each) {
-        mocked_server.should_receive(:fetch_recordings).with(filter)
+        mocked_server.should_receive(:fetch_recordings).with(filter, scope)
         post :fetch_recordings, :id => room.to_param, :format => :json
       }
       it { should respond_with(:success) }
@@ -840,7 +843,7 @@ describe Bigbluebutton::RoomsController do
     context "with :redir_url" do
       context "on success" do
         before(:each) {
-          mocked_server.should_receive(:fetch_recordings).with(filter)
+          mocked_server.should_receive(:fetch_recordings).with(filter, scope)
           post :fetch_recordings, :id => room.to_param, :redir_url => "/any"
         }
         it {should respond_with(:redirect) }

--- a/spec/factories/bigbluebutton_recording.rb
+++ b/spec/factories/bigbluebutton_recording.rb
@@ -12,6 +12,7 @@ FactoryGirl.define do
     r.sequence(:recordid) { |n| "rec#{n}-#{SecureRandom.uuid}-#{DateTime.now.to_i}" }
     r.size { rand((20*1024**2)..(500*1024**2)) } # size ranging from 20Mb to 500Mb
     r.available true
+    r.state { ['processing', 'processed', 'published', 'unpublished'].sample }
 
     after(:create) do |r|
       r.updated_at = r.updated_at.change(:usec => 0)

--- a/spec/lib/bigbluebutton_rails/configuration_spec.rb
+++ b/spec/lib/bigbluebutton_rails/configuration_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe BigbluebuttonRails::Configuration do
+
+  describe "#rooms_for_full_recording_sync" do
+    let(:config) { BigbluebuttonRails::Configuration.new }
+
+    it { expect(config.rooms_for_full_recording_sync).to be_a(Proc) }
+
+    context "returns a query to find rooms that had meetings in the past 7 days" do
+      let!(:room1) { FactoryGirl.create(:bigbluebutton_room) }
+      let!(:meeting1) {
+        create_time = DateTime.now.to_i * 1000
+        FactoryGirl.create(:bigbluebutton_meeting, room: room1, create_time: create_time)
+      }
+
+      let!(:room2) { FactoryGirl.create(:bigbluebutton_room) }
+      let!(:meeting2) {
+        create_time = (DateTime.now - 1.day).to_i * 1000
+        FactoryGirl.create(:bigbluebutton_meeting, room: room2, create_time: create_time)
+      }
+
+      let!(:room3) { FactoryGirl.create(:bigbluebutton_room) }
+      let!(:meeting3) {
+        create_time = (DateTime.now - 7.days).to_i * 1000
+        FactoryGirl.create(:bigbluebutton_meeting, room: room3, create_time: create_time)
+      }
+
+      let!(:room4) { FactoryGirl.create(:bigbluebutton_room) }
+      let!(:meeting4) {
+        create_time = (DateTime.now - 7.days - 1.second).to_i * 1000
+        FactoryGirl.create(:bigbluebutton_meeting, room: room4, create_time: create_time)
+      }
+
+      let!(:room5) { FactoryGirl.create(:bigbluebutton_room) }
+      let!(:meeting5) {
+        create_time = (DateTime.now - 8.days).to_i * 1000
+        FactoryGirl.create(:bigbluebutton_meeting, room: room5, create_time: create_time)
+      }
+
+      let(:expected) { BigbluebuttonRoom.where(id: [room1.id, room2.id, room3.id]) }
+
+      before { Timecop.freeze }
+      after { Timecop.return }
+
+      it { expect(config.rooms_for_full_recording_sync.call).to be_a(ActiveRecord::Relation) }
+      it { expect(config.rooms_for_full_recording_sync.call.to_sql.should eql(expected.to_sql)) }
+    end
+  end
+end

--- a/spec/models/bigbluebutton_room_spec.rb
+++ b/spec/models/bigbluebutton_room_spec.rb
@@ -1419,7 +1419,8 @@ describe BigbluebuttonRoom do
         let!(:meeting1) { FactoryGirl.create(:bigbluebutton_meeting, room: room, ended: false, running: true) }
         let!(:meeting2) { FactoryGirl.create(:bigbluebutton_meeting, room: room, ended: false, running: true) }
         before {
-          expect(Resque).to receive(:enqueue_in).with(1.minute, ::BigbluebuttonRecordingsForRoomWorker, room.id, 10)
+          tries = BigbluebuttonRails.configuration.recording_sync_for_room_intervals.length - 1
+          expect(Resque).to receive(:enqueue_in).with(1.minute, ::BigbluebuttonRecordingsForRoomWorker, room.id, tries)
         }
         it { room.finish_meetings }
       end

--- a/spec/models/bigbluebutton_room_spec.rb
+++ b/spec/models/bigbluebutton_room_spec.rb
@@ -1516,6 +1516,33 @@ describe BigbluebuttonRoom do
       it { room.send(:internal_create_meeting, nil, user_opts) }
     end
   end
+
+  describe "#fetch_recordings" do
+    let!(:server) { FactoryGirl.create(:bigbluebutton_server) }
+    let!(:room) { FactoryGirl.create(:bigbluebutton_room) }
+
+    it { should respond_to(:fetch_recordings) }
+
+    context "if no server is found" do
+      before {
+        room.stub(:select_server).and_return(nil)
+        server.should_not_receive(:fetch_recordings)
+      }
+
+      it { room.fetch_recordings.should be(false) }
+    end
+
+    context "if a server is found" do
+      before {
+        room.stub(:select_server).and_return(server)
+        filter = { meetingID: room.meetingid, state: BigbluebuttonRecording::STATES.values }
+        scope = BigbluebuttonRecording.where(room: room, state: BigbluebuttonRecording::STATES.values)
+        server.should_receive(:fetch_recordings).with(filter, scope)
+      }
+
+      it { room.fetch_recordings.should be(true) }
+    end
+  end
 end
 
 def get_create_params(room, user=nil)

--- a/spec/models/bigbluebutton_server_spec.rb
+++ b/spec/models/bigbluebutton_server_spec.rb
@@ -253,6 +253,8 @@ describe BigbluebuttonServer do
     let(:server) { FactoryGirl.create(:bigbluebutton_server) }
     let(:filter) { { :meetingID => "id1,id2,id3" } }
     let(:response) { { :recordings => [1, 2] } }
+    let!(:sync_started_at) { DateTime.now }
+
     before do
       @api_mock = double(BigBlueButton::BigBlueButtonApi)
       server.stub(:api).and_return(@api_mock)
@@ -263,16 +265,18 @@ describe BigbluebuttonServer do
     context "calls get_recordings and sync" do
       let(:expected_scope) { BigbluebuttonRecording.where(server: server) }
       before do
+        DateTime.should_receive(:now).once.and_return(sync_started_at)
         @api_mock.should_receive(:get_recordings).with({}).and_return(response)
-        BigbluebuttonRecording.should_receive(:sync).with(server, response[:recordings], expected_scope)
+        BigbluebuttonRecording.should_receive(:sync).with(server, response[:recordings], expected_scope, sync_started_at)
       end
       it { server.fetch_recordings }
     end
 
     context "when only a filter is informed, calls get_recordings with the filter received" do
       before do
+        DateTime.should_receive(:now).once.and_return(sync_started_at)
         @api_mock.should_receive(:get_recordings).with(filter).and_return(response)
-        BigbluebuttonRecording.should_receive(:sync).with(server, response[:recordings], nil)
+        BigbluebuttonRecording.should_receive(:sync).with(server, response[:recordings], nil, sync_started_at)
       end
       it { server.fetch_recordings(filter) }
     end
@@ -280,8 +284,9 @@ describe BigbluebuttonServer do
     context "when only a scope is informed, calls sync with the scope received" do
       let(:scope) { BigbluebuttonRecording.where(id: 1) }
       before do
+        DateTime.should_receive(:now).once.and_return(sync_started_at)
         @api_mock.should_receive(:get_recordings).with({}).and_return(response)
-        BigbluebuttonRecording.should_receive(:sync).with(server, response[:recordings], scope)
+        BigbluebuttonRecording.should_receive(:sync).with(server, response[:recordings], scope, sync_started_at)
       end
       it { server.fetch_recordings(nil, scope) }
     end

--- a/spec/workers/bigbluebutton_recordings_for_room_worker_spec.rb
+++ b/spec/workers/bigbluebutton_recordings_for_room_worker_spec.rb
@@ -14,18 +14,21 @@ describe BigbluebuttonRecordingsForRoomWorker do
         BigbluebuttonRoom.stub(:find).and_return(room)
         expect(room).to receive(:fetch_recordings).once
       }
-      it { BigbluebuttonRecordingsForRoomWorker.perform(room.id) }
+      it { BigbluebuttonRecordingsForRoomWorker.perform(room.id, 1) }
     end
 
     context "if there are still tries left" do
       before {
         BigbluebuttonRoom.stub(:find).and_return(room)
         room.stub(:fetch_recordings)
+
+        intervals = BigbluebuttonRails.configuration.recording_sync_for_room_intervals
+        wait = intervals[intervals.length - 6]
         expect(Resque).to receive(:enqueue_in)
-                           .with(5.minutes, ::BigbluebuttonRecordingsForRoomWorker, room.id, 0)
+                           .with(wait, ::BigbluebuttonRecordingsForRoomWorker, room.id, 6)
                            .once
       }
-      it { BigbluebuttonRecordingsForRoomWorker.perform(room.id, 1) }
+      it { BigbluebuttonRecordingsForRoomWorker.perform(room.id, 7) }
     end
 
     context "if there are no more tries left" do

--- a/spec/workers/bigbluebutton_update_recordings_worker_spec.rb
+++ b/spec/workers/bigbluebutton_update_recordings_worker_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe BigbluebuttonUpdateRecordingsWorker do
 
   it "runs BigbluebuttonRails::BackgroundTasks.finish_meetings" do
-    expect(BigbluebuttonRails::BackgroundTasks).to receive(:update_recordings).once
+    expect(BigbluebuttonRails::BackgroundTasks).to receive(:update_recordings_by_room).once
     BigbluebuttonUpdateRecordingsWorker.perform
   end
 

--- a/spec/workers/bigbluebutton_update_recordings_worker_spec.rb
+++ b/spec/workers/bigbluebutton_update_recordings_worker_spec.rb
@@ -2,9 +2,16 @@ require 'spec_helper'
 
 describe BigbluebuttonUpdateRecordingsWorker do
 
-  it "runs BigbluebuttonRails::BackgroundTasks.finish_meetings" do
-    expect(BigbluebuttonRails::BackgroundTasks).to receive(:update_recordings_by_room).once
-    BigbluebuttonUpdateRecordingsWorker.perform
+  context "runs BigbluebuttonRails::BackgroundTasks.finish_meetings" do
+    let(:query) { BigbluebuttonRoom.where(id: 1) }
+    let(:proc) { Proc.new {} }
+
+    before {
+      expect(proc).to receive(:call).once.and_return(query)
+      expect(BigbluebuttonRails.configuration).to receive(:rooms_for_full_recording_sync).once.and_return(proc)
+      expect(BigbluebuttonRails::BackgroundTasks).to receive(:update_recordings_by_room).once.with(query)
+    }
+    it { BigbluebuttonUpdateRecordingsWorker.perform }
   end
 
   it "uses the queue :bigbluebutton_rails" do


### PR DESCRIPTION
This PR includes the changes from the branch `improve-recording-sync` and a merge of it with PR #195.

We had issues with the worker that synchronizes recordings because it does a single `getRecordings` for each server in the database. If you have a single server with thousands of recordings, it might not work.

This PR changes the synchronization process in two ways:
* Now the job that tries to detect new recordings right after a meeting ends will run more times and for a longer time. They will run 16 times, with an increasing wait between executions, and in total will run for about 24h. Testing this in a production environment already showed us that this worker alone is enough to synchronize recordings and all their formats (as long as they are done processing in at most 24h). Applications can easily customize the intervals between each job to adapt it to their requirements, see `recording_sync_for_room_intervals`.
* The job that synchronizes all recordings will now run a `getRecordings` call for each room and not for each server. It will probably take longer to synchronize and will call `getRecordings` way more times, but each call is a lot faster and returns way less data, so it should scale better. To prevent issues in environments with thousands of rooms, by default the worker will only do a `getRecordings` for rooms that had at least one meeting in the past 7 days. This behaviour is also easy to customize, see `rooms_for_full_recording_sync`. Since the job mentioned before is working so well, the default schedule for this worker was changed so it runs only twice a day.

By including the changes from PR #195, this PR also fixes the issues of recordings being marked as unavailable if they were created after a call to `getRecordings` but before the recordings were all synchronized.