### PR TITLE
Fix meeting actions

### DIFF
--- a/lib/bigbluebutton_rails/configuration.rb
+++ b/lib/bigbluebutton_rails/configuration.rb
@@ -32,7 +32,8 @@ module BigbluebuttonRails
         servers: 'bigbluebutton/servers',
         rooms: 'bigbluebutton/rooms',
         recordings: 'bigbluebutton/recordings',
-        playback_types: 'bigbluebutton/playback_types'
+        playback_types: 'bigbluebutton/playback_types',
+        meetings: 'bigbluebutton/meetings'
       }
       @routing_scope = 'bigbluebutton'
 
@@ -133,7 +134,7 @@ module BigbluebuttonRails
 
     def set_controllers(options)
       unless options.nil? || options.empty?
-        @controllers.merge!(options).slice!(:servers, :rooms, :recordings, :playback_types)
+        @controllers.merge!(options).slice!(:servers, :rooms, :recordings, :playback_types, :meetings)
       end
     end
 

--- a/lib/bigbluebutton_rails/rails/routes.rb
+++ b/lib/bigbluebutton_rails/rails/routes.rb
@@ -162,7 +162,8 @@ module ActionDispatch::Routing
     end
 
     def add_routes_for_meetings #:nodoc:
-      resources :meetings, :controller => 'bigbluebutton/meetings', :only => [:destroy, :update, :edit]
+      resources :meetings, :only => [:destroy, :update, :edit],
+                           :controller => BigbluebuttonRails.configuration.controllers[:meetings]
     end
   end
 end


### PR DESCRIPTION
The gem was forcing the meeting's actions on their apps (like Elos' portal). Now they can be overridden if necessary.