### PR TITLE
Remove running attribute from BigbluebuttonRoom model

### DIFF
--- a/app/controllers/bigbluebutton/api/rooms_controller.rb
+++ b/app/controllers/bigbluebutton/api/rooms_controller.rb
@@ -45,7 +45,7 @@ class Bigbluebutton::Api::RoomsController < ApplicationController
   end
 
   def running
-    check_is_running
+    @running = check_is_running
   end
 
   def join
@@ -89,12 +89,11 @@ class Bigbluebutton::Api::RoomsController < ApplicationController
 
   def check_is_running
     begin
-      @room.fetch_is_running?
+      @room.is_running?
     rescue StandardError => e
       @errors = [BigbluebuttonRails::APIError.new(e.to_s, 500)]
-      render 'bigbluebutton/api/error'
+      render 'bigbluebutton/api/error' and return false
     end
-    @room.is_running?
   end
 
   def set_content_type

--- a/app/models/bigbluebutton_meeting.rb
+++ b/app/models/bigbluebutton_meeting.rb
@@ -50,7 +50,7 @@ class BigbluebuttonMeeting < ActiveRecord::Base
           title: room.name,
           recorded: room.record_meeting,
           create_time: room.create_time,
-          running: room.running,
+          running: response[:running],
           ended: false,
           internal_meeting_id: response[:internalMeetingID]
         }

--- a/app/models/bigbluebutton_room.rb
+++ b/app/models/bigbluebutton_room.rb
@@ -51,7 +51,7 @@ class BigbluebuttonRoom < ActiveRecord::Base
   validates :moderator_key, :presence => true, :if => :private?
 
   # Note: these params need to be fetched from the server before being accessed
-  attr_accessor :running, :participant_count, :moderator_count, :current_attendees,
+  attr_accessor :participant_count, :moderator_count, :current_attendees,
                 :has_been_forcibly_ended, :end_time
 
   after_initialize :init
@@ -95,7 +95,8 @@ class BigbluebuttonRoom < ActiveRecord::Base
 
   # Convenience method to access the attribute <tt>running</tt>
   def is_running?
-    @running
+    # TODO: cache this maybe?
+    fetch_is_running?
   end
 
   # Fetches info from BBB about this room.
@@ -121,7 +122,6 @@ class BigbluebuttonRoom < ActiveRecord::Base
 
       @participant_count = response[:participantCount]
       @moderator_count = response[:moderatorCount]
-      @running = response[:running]
       @has_been_forcibly_ended = response[:hasBeenForciblyEnded]
       @end_time = response[:endTime]
       @current_attendees = []
@@ -135,8 +135,8 @@ class BigbluebuttonRoom < ActiveRecord::Base
 
       # a 'shortcut' to update meetings since we have all information we need
       # if we got here, it means the meeting is still in the server, so it's not ended
-      self.update_attributes(create_time: response[:createTime]) unless self.new_record?
-      self.update_current_meeting_record(response[:metadata], true)
+      update_attributes(create_time: response[:createTime]) unless self.new_record?
+      update_current_meeting_record(response, true)
 
     rescue BigBlueButton::BigBlueButtonException => e
       # note: we could catch only the 'notFound' error, but there are complications, so
@@ -156,7 +156,7 @@ class BigbluebuttonRoom < ActiveRecord::Base
   # Triggers API call: <tt>isMeetingRunning</tt>.
   def fetch_is_running?
     server = BigbluebuttonRails.configuration.select_server.call(self, :is_meeting_running)
-    @running = server.api.is_meeting_running?(self.meetingid)
+    server.api.is_meeting_running?(self.meetingid)
   end
 
   # Sends a call to the BBB server to end the meeting.
@@ -288,7 +288,7 @@ class BigbluebuttonRoom < ActiveRecord::Base
   # if they are have all equal values.
   # From: http://alicebobandmallory.com/articles/2009/11/02/comparing-instance-variables-in-ruby
   def instance_variables_compare(o)
-    vars = [ :@running, :@participant_count, :@moderator_count, :@current_attendees,
+    vars = [ :@participant_count, :@moderator_count, :@current_attendees,
              :@has_been_forcibly_ended, :@end_time ]
     Hash[*vars.map { |v|
            self.instance_variable_get(v)!=o.instance_variable_get(v) ?
@@ -311,7 +311,6 @@ class BigbluebuttonRoom < ActiveRecord::Base
   # Will create the meeting in this room unless it is already running.
   # Returns true if the meeting was created.
   def create_meeting(user=nil, request=nil)
-    fetch_is_running?
     unless is_running?
       add_domain_to_logout_url(request.protocol, request.host_with_port) unless request.nil?
       send_create(user)
@@ -353,16 +352,13 @@ class BigbluebuttonRoom < ActiveRecord::Base
   end
 
   # Updates the current meeting associated with this room
-  def update_current_meeting_record(metadata=nil, force_not_ended=false)
-    unless self.create_time.nil?
-      attrs = {
-        :running => self.running,
-        :create_time => self.create_time
-      }
-      # note: it's important to update the 'ended' attr so the meeting is
-      # reopened in case it was mistakenly considered as ended
-      attrs[:ended] = false if force_not_ended
+  def update_current_meeting_record(response, force_not_ended=false)
+    attrs = {}
+    unless response.nil?
+      attrs[:running] = response[:running]
+      attrs[:create_time] = response[:createTime]
 
+      metadata = response[:metadata]
       unless metadata.nil?
         begin
           attrs[:creator_id] = metadata[BigbluebuttonRails.configuration.metadata_user_id].to_i
@@ -372,10 +368,13 @@ class BigbluebuttonRoom < ActiveRecord::Base
           attrs[:creator_name] = nil
         end
       end
-
-      meeting = self.get_current_meeting
-      meeting.update_attributes(attrs) if meeting.present?
     end
+    # note: it's important to update the 'ended' attr so the meeting is
+    # reopened in case it was mistakenly considered as ended
+    attrs[:ended] = false if force_not_ended
+
+    meeting = self.get_current_meeting
+    meeting.update_attributes(attrs) if meeting.present?
   end
 
   # Sets all meetings related to this room as not running
@@ -462,7 +461,6 @@ class BigbluebuttonRoom < ActiveRecord::Base
     # fetched attributes
     @participant_count = 0
     @moderator_count = 0
-    @running = false
     @has_been_forcibly_ended = false
     @end_time = nil
     @current_attendees = []

--- a/app/models/bigbluebutton_room.rb
+++ b/app/models/bigbluebutton_room.rb
@@ -108,7 +108,6 @@ class BigbluebuttonRoom < ActiveRecord::Base
   # The attributes changed are:
   # * <tt>participant_count</tt>
   # * <tt>moderator_count</tt>
-  # * <tt>running</tt>
   # * <tt>has_been_forcibly_ended</tt>
   # * <tt>create_time</tt>
   # * <tt>end_time</tt>

--- a/app/models/bigbluebutton_server.rb
+++ b/app/models/bigbluebutton_server.rb
@@ -93,8 +93,7 @@ class BigbluebuttonServer < ActiveRecord::Base
         room.update_attributes(attendee_api_password: attr[:attendeePW],
                                moderator_api_password: attr[:moderatorPW])
       end
-      room.running = attr[:running]
-      room.update_current_meeting_record
+      room.update_current_meeting_record(attr)
 
       @meetings << room
     end

--- a/app/views/bigbluebutton/api/rooms/running.rabl
+++ b/app/views/bigbluebutton/api/rooms/running.rabl
@@ -5,6 +5,6 @@ child(@room => :data) {
   node(:id) { |obj| obj.to_param }
 
   node :attributes do |room|
-    { :running => room.is_running? }
+    { :running => @running }
   end
 }

--- a/spec/controllers/bigbluebutton/servers_controller_spec.rb
+++ b/spec/controllers/bigbluebutton/servers_controller_spec.rb
@@ -282,6 +282,8 @@ describe Bigbluebutton::ServersController do
         server.should_receive(:meetings).at_least(:once).and_return([room1, room2])
         room1.should_receive(:fetch_meeting_info)
         room2.should_receive(:fetch_meeting_info)
+        room1.should_receive(:fetch_is_running?)
+        room2.should_receive(:fetch_is_running?)
       end
 
       context do
@@ -318,6 +320,8 @@ describe Bigbluebutton::ServersController do
           server.should_receive(:fetch_meetings).and_return({ })
           server.should_receive(:meetings).at_least(:once).and_return([room1, room2])
           room1.should_receive(:fetch_meeting_info) { raise bbb_error }
+          room1.should_receive(:fetch_is_running?)
+          room2.should_receive(:fetch_is_running?)
         end
         before(:each) { get :activity, :id => server.to_param }
         it { should set_the_flash.to(api_error_msg(bbb_error)) }

--- a/spec/models/bigbluebutton_meeting_spec.rb
+++ b/spec/models/bigbluebutton_meeting_spec.rb
@@ -82,16 +82,16 @@ describe BigbluebuttonMeeting do
       }
       before {
         room.create_time = Time.now.utc
-        room.running = !room.running # to change its default value
         room.record_meeting = !room.record_meeting # to change its default value
         room.create_time = Time.at(Time.now.to_i - 123)  # to change its default value
       }
 
       context "if there's no meeting associated yet creates one" do
         context "and there's no metadata in the response" do
+          let(:running) { false }
           before(:each) {
             expect {
-              BigbluebuttonMeeting.create_meeting_record_from_room(room, {internalMeetingID: 'fake-id'}, server, nil, {})
+              BigbluebuttonMeeting.create_meeting_record_from_room(room, {internalMeetingID: 'fake-id', running: running}, server, nil, {})
             }.to change{ BigbluebuttonMeeting.count }.by(1)
           }
           subject { BigbluebuttonMeeting.last }
@@ -101,7 +101,9 @@ describe BigbluebuttonMeeting do
           it("sets meetingid") { subject.meetingid.should eq(room.meetingid) }
           it("sets name") { subject.name.should eq(room.name) }
           it("sets recorded") { subject.recorded.should eq(room.record_meeting) }
-          it("sets running") { subject.running.should eq(room.running) }
+          it("sets running") {
+            room.should_receive(:fetch_is_running?).and_return(running)
+            subject.running.should eq(room.is_running?) }
           it("sets create_time") { subject.create_time.should eq(room.create_time.to_i) }
           it("doesn't set creator_id") { subject.creator_id.should be_nil }
           it("doesn't set creator_name") { subject.creator_name.should be_nil }

--- a/spec/models/bigbluebutton_server_spec.rb
+++ b/spec/models/bigbluebutton_server_spec.rb
@@ -173,9 +173,9 @@ describe BigbluebuttonServer do
     # the hashes should be exactly as returned by bigbluebutton-api-ruby to be sure we are testing it right
     let(:meetings) {
       [
-       { :meetingID => room1.meetingid, :attendeePW => "ap", :moderatorPW => "mp", :hasBeenForciblyEnded => false, :running => true},
-       { :meetingID => room2.meetingid, :attendeePW => "pass", :moderatorPW => "pass", :hasBeenForciblyEnded => true, :running => false},
-       { :meetingID => "im not in the db", :attendeePW => "pass", :moderatorPW => "pass", :hasBeenForciblyEnded => true, :running => true}
+       { :meetingID => room1.meetingid, createTime: Time.now.to_i, :attendeePW => "ap", :moderatorPW => "mp", :hasBeenForciblyEnded => false, :running => true},
+       { :meetingID => room2.meetingid, createTime: Time.now.to_i + 123, :attendeePW => "pass", :moderatorPW => "pass", :hasBeenForciblyEnded => true, :running => false},
+       { :meetingID => "im not in the db", createTime: Time.now.to_i + 234, :attendeePW => "pass", :moderatorPW => "pass", :hasBeenForciblyEnded => true, :running => true}
       ]
     }
     let(:hash) {
@@ -204,7 +204,6 @@ describe BigbluebuttonServer do
     it { server.meetings[2].name.should == "im not in the db" }
     it { server.meetings[2].attendee_api_password.should == "pass" }
     it { server.meetings[2].moderator_api_password.should == "pass" }
-    it { server.meetings[2].running.should == true }
     it { server.meetings[2].new_record?.should be_truthy }
     it { server.meetings[2].external.should be_truthy }
     it { server.meetings[2].private.should be_truthy  }


### PR DESCRIPTION
The running accessors (read and write) were removed, so you can't use 
- `room.running = val`
or
- `val = room.running`
anymore.

The `is_running?` method now calls `fetch_is_running`, so it's no longer necessary to call `fetch_is_running`.



